### PR TITLE
Fix a memory leak in TCP communication caused by optimization by the JVM.

### DIFF
--- a/modules/rescuecore2/src/rescuecore2/connection/StreamConnection.java
+++ b/modules/rescuecore2/src/rescuecore2/connection/StreamConnection.java
@@ -106,10 +106,12 @@ public class StreamConnection extends AbstractConnection {
     private class ReadThread extends WorkerThread {
         @Override
         protected boolean work() {
+            byte[] buffer = {};
+	    int size = -1;
             try {
-                int size = readInt32(in);
+                size = readInt32(in);
                 if (size > 0) {
-                    byte[] buffer = readBytes(size, in);
+                    buffer = readBytes(size, in);
                     bytesReceived(buffer);
                 }
                 return true;


### PR DESCRIPTION
Fix a memory leak in TCP communication caused by optimization by the JVM.

With this change, optimization is suppressed and the problem does not occur.