### PR TITLE
FIX a bug that ClearSimulator's ChangeSet conflicts with CollapseSimulator's

### DIFF
--- a/modules/rescuecore2/src/rescuecore2/worldmodel/ChangeSet.java
+++ b/modules/rescuecore2/src/rescuecore2/worldmodel/ChangeSet.java
@@ -152,6 +152,8 @@ public class ChangeSet {
                 if (p.getURN().equals(BLOCKADES_URN) &&
                     changes.get(e).containsKey(BLOCKADES_URN)) {
 
+                    System.err.println("------------ CALLED ------------");
+
                     EntityRefListProperty bp1 = (EntityRefListProperty)p.copy();
                     EntityRefListProperty bp2 =
                         (EntityRefListProperty)changes.get(e).get(BLOCKADES_URN);

--- a/modules/rescuecore2/src/rescuecore2/worldmodel/properties/EntityRefListProperty.java
+++ b/modules/rescuecore2/src/rescuecore2/worldmodel/properties/EntityRefListProperty.java
@@ -99,6 +99,19 @@ public class EntityRefListProperty extends AbstractProperty {
     }
 
     /**
+       Remove a value from the list.
+       @param id The id to remove.
+     */
+    public void removeValue(EntityID id) {
+        List<EntityID> old = new ArrayList<EntityID>(ids);
+        ids.remove(id);
+
+        if (ids.isEmpty()) undefine();
+
+        fireChange(old, Collections.unmodifiableList(ids));
+    }
+
+    /**
        Remove all entries from this list but keep it defined.
      */
     public void clearValues() {


### PR DESCRIPTION
The merge method of ChangeSet has a bug.

When CollapseSimulator creates Blockades on a road A after aftershock and CollapseSimulator removes a Blockades from the road A by AKClearArea, one of changes is ignored on merging them.

This bug causes following error messages:
ERROR kernel : Blockade xxxxxxxx is null!
ERROR kernel : Road [...]

If you would accept this pull request, I would like you to do more tests.