### PR TITLE
Add gmlEditor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,3 +209,11 @@ task logViewer(type: JavaExec) {
   maxHeapSize = '2048m'
   args = [ 'boot/logs/rescue.log' ]
 }
+
+/*Open gml editor */
+task gmlEditor(type: JavaExec) {
+  classpath = sourceSets.main.runtimeClasspath
+  main = 'maps.gml.editor.GMLEditor'
+  maxHeapSize = '2048m'
+  args = [ 'maps/gml/test/map/map.gml' ]
+}


### PR DESCRIPTION
There is no task launching gml-editor (this task existed when rcrs-server was built by ant) on build.gradle.
I added that task to build.gradle to be able to lauch gml-editor.