### PR TITLE
FIX the bug boot/logextract.sh never ends

### DIFF
--- a/modules/rescuecore2/src/rescuecore2/log/LogExtractor.java
+++ b/modules/rescuecore2/src/rescuecore2/log/LogExtractor.java
@@ -213,6 +213,8 @@ public class LogExtractor {
         catch (LogException e) {
             Logger.error("Error reading log", e);
         }
+
+        System.exit(0);
     }
     
     private static void writeFile(String filename, String content) {


### PR DESCRIPTION
boot/logextract.sh never ends.
Therefore, we need to terminate it with Ctrl-C, even if it exits successfully.