### PR TITLE
REMOVE an unused variable from TrafficSimulator for no X11 environment

### DIFF
--- a/modules/traffic3/src/traffic3/simulator/TrafficSimulator.java
+++ b/modules/traffic3/src/traffic3/simulator/TrafficSimulator.java
@@ -499,7 +499,7 @@ public class TrafficSimulator extends StandardSimulator implements GUIComponent 
 
 	}
 
-	public static ShapeDebugFrame debug = new ShapeDebugFrame();
+	// public static ShapeDebugFrame debug = new ShapeDebugFrame();
 
 	private Collection<? extends PathElement> getPathElements2(Human human, Area lastArea, Edge lastEdge, Area nextArea, Edge nextEdge) {
 		// if (human instanceof Civilian)


### PR DESCRIPTION
We should be able to launch the server on no X11 environment with “—nogui” option.
But, an unused variable of TrafficSimulator interrupts it.