### PR TITLE
fixed functions.sh for MacOS/BSD systems

### DIFF
--- a/boot/functions.sh
+++ b/boot/functions.sh
@@ -142,7 +142,10 @@ function processArgs {
           LOGDIR="$LOGDIR/$TIME-$TEAM-$MAPNAME"
         fi
     fi
-    LOGDIR=`readlink -f $LOGDIR`
+    
+    if [ "$(uname -s)" = 'Linux' ]; then
+        LOGDIR=`readlink -f $LOGDIR`
+    fi
     mkdir -p $LOGDIR
 }
 


### PR DESCRIPTION
readlink -f option is not present on BSD systems which causes problems during launch.