### PR TITLE
improved KernelGUI

### DIFF
--- a/modules/kernel/src/kernel/StartKernel.java
+++ b/modules/kernel/src/kernel/StartKernel.java
@@ -194,6 +194,7 @@ public final class StartKernel {
 					}
 				}
 				JFrame frame = new JFrame("Kernel GUI");
+				frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
 				frame.getContentPane().add(gui);
 				frame.pack();
 				frame.addWindowListener(new WindowAdapter() {

--- a/modules/standard/src/rescuecore2/standard/kernel/StandardWorldModelViewerComponent.java
+++ b/modules/standard/src/rescuecore2/standard/kernel/StandardWorldModelViewerComponent.java
@@ -79,6 +79,7 @@ public class StandardWorldModelViewerComponent extends KernelListenerAdapter imp
                 }
             });
         JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, viewer, new JScrollPane(inspector));
+        split.setResizeWeight(0.8);
         view = new JPanel(new BorderLayout());
         view.add(split, BorderLayout.CENTER);
         view.add(field, BorderLayout.NORTH);


### PR DESCRIPTION
JSplitPane in the WorldView tab inside the KernelGUI allocates almost all the space available to the right component, which is annoying and you must adjust it manually every time you launch the server. this commit fixes that issue.
also this makes the KernelGUI launch in full-sized window which is more preferable.

Before: 
<img width="1508" alt="Screen Shot 2020-02-18 at 3 19 56 PM" src="https://user-images.githubusercontent.com/18077424/74734083-12456880-5263-11ea-9144-068e23e42009.png">

After:
<img width="1552" alt="Screen Shot 2020-02-18 at 3 12 02 PM" src="https://user-images.githubusercontent.com/18077424/74734105-20938480-5263-11ea-9502-5a173734090a.png">
