### PR TITLE
Visibility will be taken from the constructor of each viewer

### DIFF
--- a/modules/standard/src/rescuecore2/standard/view/StandardViewLayer.java
+++ b/modules/standard/src/rescuecore2/standard/view/StandardViewLayer.java
@@ -31,7 +31,7 @@ public abstract class StandardViewLayer extends AbstractViewLayer {
     @Override
     public void initialise(Config config) {
         String visibleKey = STANDARD_VIEWER_PREFIX + "." + this.getClass().getSimpleName() + "." + VISIBILITY_SUFFIX;
-        boolean isVisible = config.getBooleanValue(visibleKey, true);
+        boolean isVisible = config.getBooleanValue(visibleKey, isVisible());
         setVisible(isVisible);
     }
 


### PR DESCRIPTION
Some viewlayers by default starts invisible (such as area neighbor viewer, that visibility set at the constructor of that viewer), but this visibility is overridden while reading from config.