### PR TITLE
FIX result-consistency

### DIFF
--- a/boot/functions.sh
+++ b/boot/functions.sh
@@ -60,7 +60,7 @@ function printUsage {
     echo "-t    --team      <teamname>  Set the team name. Default: \"\""
     echo "-l    --log       <logdir>    Set the log directory. Default: \"logs\""
     echo "-s    --timestamp             Create a log sub-directory including timestamp, team name and map name"
-    echo "-g    --nogui                 Disable GUI."
+    echo "-g    --nogui                 Disable GUI"
     echo "[+|-]x                        Enable/Disable XTerm use. Default: \"Disable\""
 }
 
@@ -192,27 +192,26 @@ function startSims {
 
     # Execute the simulators
     execute misc "java -Xmx512m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/misc.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents misc.MiscSimulator -c $CONFIGDIR/misc.cfg $GUI_OPTION $*"
-    execute traffic "java -Xmx1024m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/traffic3.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents traffic3.simulator.TrafficSimulator -c $CONFIGDIR/traffic3.cfg $GUI_OPTION $*"
-    execute fire "java -Xmx1024m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/resq-fire.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents firesimulator.FireSimulatorWrapper -c $CONFIGDIR/resq-fire.cfg $GUI_OPTION $*"
-    execute ignition "java -Xmx512m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/ignition.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents ignition.IgnitionSimulator -c $CONFIGDIR/ignition.cfg $GUI_OPTION $*"
-    execute collapse "java -Xmx512m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/collapse.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents collapse.CollapseSimulator -c $CONFIGDIR/collapse.cfg $GUI_OPTION $*"
-    execute clear "java -Xmx512m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/clear.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents clear.ClearSimulator -c $CONFIGDIR/clear.cfg $GUI_OPTION $*"
-
     echo "waiting for misc to connect..."
     waitFor $LOGDIR/misc-out.log "success"
 
+    execute traffic "java -Xmx1024m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/traffic3.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents traffic3.simulator.TrafficSimulator -c $CONFIGDIR/traffic3.cfg $GUI_OPTION $*"
     echo "waiting for traffic to connect..."
     waitFor $LOGDIR/traffic-out.log "success"
 
+    execute fire "java -Xmx1024m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/resq-fire.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents firesimulator.FireSimulatorWrapper -c $CONFIGDIR/resq-fire.cfg $GUI_OPTION $*"
     echo "waiting for fire to connect..."
     waitFor $LOGDIR/fire-out.log "success"
 
+    execute ignition "java -Xmx512m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/ignition.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents ignition.IgnitionSimulator -c $CONFIGDIR/ignition.cfg $GUI_OPTION $*"
     echo "waiting for ignition to connect..."
     waitFor $LOGDIR/ignition-out.log "success"
 
+    execute collapse "java -Xmx512m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/collapse.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents collapse.CollapseSimulator -c $CONFIGDIR/collapse.cfg $GUI_OPTION $*"
     echo "waiting for collapse to connect..."
     waitFor $LOGDIR/collapse-out.log "success"
 
+    execute clear "java -Xmx512m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/clear.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents clear.ClearSimulator -c $CONFIGDIR/clear.cfg $GUI_OPTION $*"
     echo "waiting for clear to connect..."
     waitFor $LOGDIR/clear-out.log "success"
 
@@ -234,7 +233,6 @@ function startViewer {
 
     # Execute the viewer
     execute viewer "java -Xmx512m -cp $CP:$BASEDIR/jars/rescuecore2.jar:$BASEDIR/jars/standard.jar:$BASEDIR/jars/sample.jar -Dlog4j.log.dir=$LOGDIR rescuecore2.LaunchComponents sample.SampleViewer -c $CONFIGDIR/viewer.cfg $TEAM_NAME_ARG $*"
-
     echo "waiting for viewer to connect..."
     waitFor $LOGDIR/viewer-out.log "success"
 }

--- a/modules/kernel/src/kernel/AbstractCommunicationModel.java
+++ b/modules/kernel/src/kernel/AbstractCommunicationModel.java
@@ -1,8 +1,8 @@
 package kernel;
 
 import java.util.Collection;
-import java.util.Set;
-import java.util.HashSet;
+import java.util.List;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Arrays;
 
@@ -16,16 +16,16 @@ import rescuecore2.misc.collections.LazyMap;
    Abstract base class for communication models.
  */
 public abstract class AbstractCommunicationModel implements CommunicationModel {
-    private Map<Entity, Set<Command>> hearing;
+    private Map<Entity, List<Command>> hearing;
 
     /**
        Construct an AbstractCommunicationModel.
     */
     public AbstractCommunicationModel() {
-        hearing = new LazyMap<Entity, Set<Command>>() {
+        hearing = new LazyMap<Entity, List<Command>>() {
             @Override
-            public Set<Command> createValue() {
-                return new HashSet<Command>();
+            public List<Command> createValue() {
+                return new LinkedList<Command>();
             }
         };
     }

--- a/modules/kernel/src/kernel/AgentProxy.java
+++ b/modules/kernel/src/kernel/AgentProxy.java
@@ -108,4 +108,9 @@ public class AgentProxy extends AbstractKernelComponent {
             }
         }
     }
+
+    @Override
+    public int hashCode() {
+        return entity.getID().hashCode();
+    }
 }

--- a/modules/kernel/src/kernel/Kernel.java
+++ b/modules/kernel/src/kernel/Kernel.java
@@ -4,9 +4,11 @@ package kernel;
 import java.util.Collections;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.TreeSet;
 import java.util.Set;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.io.IOException;
 import java.io.File;
 
@@ -103,7 +105,12 @@ public class Kernel {
             this.commandCollector = collector;
             this.idGenerator = idGenerator;
             listeners = new HashSet<KernelListener>();
-            agents = new HashSet<AgentProxy>();
+            agents = new TreeSet<AgentProxy>(new Comparator<AgentProxy>() {
+                @Override
+                public int compare(AgentProxy o1, AgentProxy o2) {
+                    return Integer.compare(o1.hashCode(), o2.hashCode());
+                }
+            });
             sims = new HashSet<SimulatorProxy>();
             viewers = new HashSet<ViewerProxy>();
             time = 0;

--- a/modules/kernel/src/kernel/SimulatorProxy.java
+++ b/modules/kernel/src/kernel/SimulatorProxy.java
@@ -138,4 +138,9 @@ public class SimulatorProxy extends AbstractKernelComponent {
             }
         }
     }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(id);
+    }
 }

--- a/modules/kernel/src/kernel/ViewerProxy.java
+++ b/modules/kernel/src/kernel/ViewerProxy.java
@@ -33,4 +33,9 @@ public class ViewerProxy extends AbstractKernelComponent {
     public String toString() {
         return getName() + " (" + id + "): " + getConnection().toString();
     }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(id);
+    }
 }

--- a/modules/standard/src/rescuecore2/standard/kernel/LineOfSightPerception.java
+++ b/modules/standard/src/rescuecore2/standard/kernel/LineOfSightPerception.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
@@ -327,7 +328,7 @@ public class LineOfSightPerception implements Perception, GUIComponent {
     }
 
     private Collection<LineInfo> getAllLines(Collection<StandardEntity> entities) {
-        Collection<LineInfo> result = new HashSet<LineInfo>();
+        Collection<LineInfo> result = new LinkedList<LineInfo>();
         for (StandardEntity next : entities) {
             if (next instanceof Building) {
                 for (Edge edge : ((Building)next).getEdges()) {

--- a/modules/traffic3/src/traffic3/objects/TrafficAgent.java
+++ b/modules/traffic3/src/traffic3/objects/TrafficAgent.java
@@ -1156,4 +1156,9 @@ public class TrafficAgent {
 		sb.append("]");
 		return sb.toString();
 	}
+
+	@Override
+	public int hashCode() {
+		return human.getID().hashCode();
+	}
 }

--- a/modules/traffic3/src/traffic3/objects/TrafficArea.java
+++ b/modules/traffic3/src/traffic3/objects/TrafficArea.java
@@ -482,4 +482,8 @@ public class TrafficArea {
 
 	}
 
+	@Override
+	public int hashCode() {
+		return area.getID().hashCode();
+	}
 }

--- a/modules/traffic3/src/traffic3/objects/TrafficBlockade.java
+++ b/modules/traffic3/src/traffic3/objects/TrafficBlockade.java
@@ -86,4 +86,9 @@ public class TrafficBlockade {
     public boolean contains(double x, double y) {
         return blockade.getShape().contains(x, y);
     }
+
+    @Override
+    public int hashCode() {
+        return blockade.getID().hashCode();
+    }
 }


### PR DESCRIPTION
The scores are often different in each simulation of the same map/scenario, even if its random seed is the same and its agents have no randomness.
This pull request fixes this problem.

This problem is caused by the iteration order of `HashSet`.
This server includes the codes that the iteration order on `HashSet` affects its result.
However, the Java Document describes the following specification:
> It makes no guarantees as to the iteration order of the set.

To avoid the specification, we need to implement `hashCode` method and unify the order of addition/deletion, or use other collection classes such as `LinkedList` / `TreeSet`.
This pull request follows the way.

I made this revision run 30 simulations for each map/scenario (of RoboCup 2019 Final) with rrs-adf-sample<sup>1</sup> on a similar environment to competitions.
Each simulation of any map/scenario outputs the following common score:

| Map/Scenario | Score |
| :- | :- |
| SydneyS2 | 174.82224338359 |
| SF2 | 237.36672811420 |
| VC2 | Time-Out (Precompute) |
| Paris2 | Time-Out (Precompute) |
| Eindhoven2 | 200.82465349198 |
| Berlin2 | Time-Out (Precompute) |

I also made AIT-Rescue for RoboCup 2020 run on the same experiment, and these scores have no variety on the same map/scenario.
Of course, scores changed clearly when the random seed is changed.

<sup>1</sup> I modified the following lines of `SampleKMeans.java` to remove randomness on rrs-adf-sample.
```java
182: Random random = new Random(1);
```
```java
275: Random random = new Random(1);
```