### PR TITLE
FIX ConcurrentModificationException

### DIFF
--- a/modules/kernel/src/kernel/AgentProxy.java
+++ b/modules/kernel/src/kernel/AgentProxy.java
@@ -61,7 +61,7 @@ public class AgentProxy extends AbstractKernelComponent {
     public Collection<Command> getAgentCommands(int timestep) {
         Collection<Command> result;
         synchronized (commands) {
-            result = commands.get(timestep);
+            result = new ArrayList<>(commands.get(timestep));
         }
         Logger.trace(entity.toString() + " getAgentCommands(" + timestep + ") returning " + result);
         return result;


### PR DESCRIPTION
Sometimes, we can see the following exception:

```
java.util.concurrent.ExecutionException: java.util.ConcurrentModificationException
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at kernel.CompositeCommandCollector.getAgentCommands(CompositeCommandCollector.java:55)
	at kernel.Kernel.waitForCommands(Kernel.java:471)
	at kernel.Kernel.timestep(Kernel.java:356)
	at kernel.StartKernel.main(StartKernel.java:214)
Caused by: java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1009)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:963)
	at java.base/java.util.AbstractCollection.toString(AbstractCollection.java:456)
	at java.base/java.lang.String.valueOf(String.java:3352)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:166)
	at kernel.AgentProxy.getAgentCommands(AgentProxy.java:66)
	at rescuecore2.standard.kernel.StandardCommandCollector.getAgentCommands(StandardCommandCollector.java:39)
	at kernel.CompositeCommandCollector$ChildCommandsFetcher.call(CompositeCommandCollector.java:106)
	at kernel.CompositeCommandCollector$ChildCommandsFetcher.call(CompositeCommandCollector.java:93)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:830)
```

The exception probably causes wrong results.
This PR fixes the problem.