### PR TITLE
Fix to TrafficManager ConcurrentModificationException

### DIFF
--- a/modules/traffic3/src/traffic3/manager/TrafficManager.java
+++ b/modules/traffic3/src/traffic3/manager/TrafficManager.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Properties;
 import java.util.List;
 import java.util.ArrayList;
@@ -46,11 +46,11 @@ public class TrafficManager {
        Construct a new TrafficManager.
     */
     public TrafficManager() {
-        areas = new HashMap<Area, TrafficArea>();
-        areaByID = new HashMap<Integer, TrafficArea>();
-        blocks = new HashMap<Blockade, TrafficBlockade>();
-        blockadeByID = new HashMap<Integer, TrafficBlockade>();
-        agents = new HashMap<Human, TrafficAgent>();
+        areas = new ConcurrentHashMap<Area, TrafficArea>();
+        areaByID = new ConcurrentHashMap<Integer, TrafficArea>();
+        blocks = new ConcurrentHashMap<Blockade, TrafficBlockade>();
+        blockadeByID = new ConcurrentHashMap<Integer, TrafficBlockade>();
+        agents = new ConcurrentHashMap<Human, TrafficAgent>();
         areaNeighbours = new LazyMap<TrafficArea, Collection<TrafficArea>>() {
             @Override
             public Collection<TrafficArea> createValue() {


### PR DESCRIPTION
The Traffic simulator generates the `ConcurrentModificationException` as shown below.

```
Exception in thread "AWT-EventQueue-0" java.util.ConcurrentModificationException
        at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1495)
        at java.base/java.util.HashMap$ValueIterator.next(HashMap.java:1523)
        at java.base/java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1047)
        at traffic3.simulator.TrafficSimulatorGUI$WorldView.drawBlockades(TrafficSimulatorGUI.java:347)
        at traffic3.simulator.TrafficSimulatorGUI$WorldView.drawObjects(TrafficSimulatorGUI.java:281)
        at traffic3.simulator.TrafficSimulatorGUI$WorldView.paintComponent(TrafficSimulatorGUI.java:272)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1074)
        at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:907)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1083)
        at java.desktop/javax.swing.JComponent.paintToOffscreen(JComponent.java:5255)
        at java.desktop/javax.swing.BufferStrategyPaintManager.paint(BufferStrategyPaintManager.java:246)
        at java.desktop/javax.swing.RepaintManager.paint(RepaintManager.java:1323)
        at java.desktop/javax.swing.JComponent._paintImmediately(JComponent.java:5203)
        at java.desktop/javax.swing.JComponent.paintImmediately(JComponent.java:5013)
        at java.desktop/javax.swing.RepaintManager$4.run(RepaintManager.java:865)
        at java.desktop/javax.swing.RepaintManager$4.run(RepaintManager.java:848)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
        at java.desktop/javax.swing.RepaintManager.paintDirtyRegions(RepaintManager.java:848)
        at java.desktop/javax.swing.RepaintManager.paintDirtyRegions(RepaintManager.java:823)
        at java.desktop/javax.swing.RepaintManager.prePaintDirtyRegions(RepaintManager.java:772)
        at java.desktop/javax.swing.RepaintManager$ProcessingRunnable.run(RepaintManager.java:1884)
        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```

The PR solves the problem by replacing the `java.util.HashMap` with the `java.util.concurrent.ConcurrentHashMap` in the `traffic3.manager.TrafficManager.java`.