### PR TITLE
FIX Math.random() -> Random with a randomseed

### DIFF
--- a/oldsims/firesimulator/util/Geometry.java
+++ b/oldsims/firesimulator/util/Geometry.java
@@ -90,7 +90,7 @@ public class Geometry {
 		if(mb==null){
             //vertical line
             int p = Math.max(a.y,b.y)-Math.min(a.y,b.y);
-            p = (int) (p*Math.random());
+            p = (int) (p*Rnd.get01());
             p = p + Math.min(a.y,b.y);
             return new Point(a.x,p);
         }


### PR DESCRIPTION
Some pseudo-random numbers are used when the fire simulator initializes itself.
These are saved as a `.rays` file and it is used after the second time on the same scenario.
One of the pseudo-random numbers is calculated without a random seed on the configuration file.

Therefore, there is no difference in results on the same computer by the `.rays` file, but there is a difference between more than one computer.
This PR fixes this problem by modifying `Math.random()` to another random method with the random seed.
I also found `Math.random()` in other codes, but these are unrelated to any simulation.