### PR TITLE
Add SampleViewerEventLogger exception handling

### DIFF
--- a/modules/sample/src/sample/SampleViewerEventLogger.java
+++ b/modules/sample/src/sample/SampleViewerEventLogger.java
@@ -72,17 +72,25 @@ public class SampleViewerEventLogger extends StandardViewer {
     super.handleTimestep( kvt );
 
     JSONObject jsonInfo = generateInfo( kvt );
-    JSONArray jsonEntities = generateChanges( kvt );
-    JSONArray jsonDeletedEntities = getDeletedEntities( kvt );
-    JSONArray jsonCommands = getCommandActionLog( kvt );
-
     JSONObject jsonRecord = new JSONObject();
 
+    JSONArray jsonEntities = new JSONArray();
+    JSONArray jsonDeletedEntities = new JSONArray();
+    JSONArray jsonCommands = new JSONArray();
+
+    try {
+        jsonEntities = generateChanges( kvt );
+        jsonDeletedEntities = getDeletedEntities( kvt );
+        jsonCommands = getCommandActionLog( kvt );
+    } catch(Exception e) {
+       e.printStackTrace();
+    }
+
+    jsonRecord.put( "Info", jsonInfo );
+    jsonRecord.put( "TimeStep", kvt.getTime() );
     jsonRecord.put( "Commands", jsonCommands );
     jsonRecord.put( "Entities", jsonEntities );
     jsonRecord.put( "DeletedEntities", jsonDeletedEntities );
-    jsonRecord.put( "Info", jsonInfo );
-    jsonRecord.put( "TimeStep", kvt.getTime() );
 
     writeJsonFile( jsonRecord, logFilePath, true );
   }
@@ -91,7 +99,11 @@ public class SampleViewerEventLogger extends StandardViewer {
   private JSONArray generateMap() {
     JSONArray jsonAllEntities = new JSONArray();
     for ( Entity entity : model.getAllEntities() ) {
-      jsonAllEntities.put( entity.toJson() );
+      try {
+        jsonAllEntities.put( entity.toJson() );
+      } catch(Exception e) {
+        e.printStackTrace();
+      }
     }
     return jsonAllEntities;
   }
@@ -139,22 +151,25 @@ public class SampleViewerEventLogger extends StandardViewer {
       Entity entity = model.getEntity( id );
       Set<Property> changedProperties = kvt.getChangeSet()
           .getChangedProperties( entity.getID() );
-
-      // Filter Entity
-      JSONObject jsonEntity = entity.toJson();
-      JSONObject filteredJsonEntity = new JSONObject();
-      for ( Property property : changedProperties ) {
-        String propertyName = property.getURN();
-        if ( jsonEntity.has( propertyName )
-            && !jsonEntity.isNull( propertyName ) ) {
-          String jsonEntityProperty = jsonEntity.get( propertyName ).toString();
-          filteredJsonEntity.put( propertyName, jsonEntityProperty );
+      try {
+        // Filter Entity
+        JSONObject jsonEntity = entity.toJson();
+        JSONObject filteredJsonEntity = new JSONObject();
+        for ( Property property : changedProperties ) {
+          String propertyName = property.getURN();
+          if ( jsonEntity.has( propertyName )
+              && !jsonEntity.isNull( propertyName ) ) {
+            String jsonEntityProperty = jsonEntity.get( propertyName ).toString();
+            filteredJsonEntity.put( propertyName, jsonEntityProperty );
+          }
         }
-      }
 
-      if ( !filteredJsonEntity.isEmpty() ) {
-        filteredJsonEntity.put( "Id", jsonEntity.get( "Id" ) );
-        jsonEntities.put( jsonEntity );
+        if ( !filteredJsonEntity.isEmpty() ) {
+          filteredJsonEntity.put( "Id", jsonEntity.get( "Id" ) );
+          jsonEntities.put( jsonEntity );
+        }
+      } catch(Exception e) {
+        e.printStackTrace();
       }
     }
 
@@ -165,7 +180,11 @@ public class SampleViewerEventLogger extends StandardViewer {
   private JSONArray getDeletedEntities( final KVTimestep kvt ) {
     JSONArray jsonDeletedEntities = new JSONArray();
     for ( EntityID id : kvt.getChangeSet().getDeletedEntities() ) {
-      jsonDeletedEntities.put( id.getValue() );
+      try {
+        jsonDeletedEntities.put( id.getValue() );
+      } catch(Exception e) {
+        e.printStackTrace();
+      }
     }
 
     return jsonDeletedEntities;
@@ -185,8 +204,12 @@ public class SampleViewerEventLogger extends StandardViewer {
     for ( Command command : t.getCommands() ) {
       StandardMessageURN commandStandardMessageURN = StandardMessageURN
           .fromString( command.getURN() );
-      if ( allowed_command_child.contains( commandStandardMessageURN ) ) {
-        jsonAllEntities.put( command.toJson() );
+      try {
+        if ( allowed_command_child.contains( commandStandardMessageURN ) ) {
+          jsonAllEntities.put( command.toJson() );
+        }
+      } catch(Exception e) {
+        e.printStackTrace();
       }
     }
     return jsonAllEntities;


### PR DESCRIPTION
We had to add a handling exception in the source because there were some issues with the server parameters.
that should not have affected the entire execution process.

like:
```
java.lang.NullPointerException
	at rescuecore2.standard.entities.Human.getX(Human.java:486)
	at rescuecore2.standard.entities.Human.toJson(Human.java:661)
	at sample.SampleViewerEventLogger.generateChanges(SampleViewerEventLogger.java:156)
	at sample.SampleViewerEventLogger.handleTimestep(SampleViewerEventLogger.java:82)
	at rescuecore2.components.AbstractViewer.processMessage(AbstractViewer.java:87)
	at rescuecore2.components.AbstractComponent$MessageProcessor.work(AbstractComponent.java:195)
	at rescuecore2.misc.WorkerThread.run(WorkerThread.java:48)
```

in this part of code:
```
  @Override
  public JSONObject toJson() {
    JSONObject jsonObject = super.toJson();
    jsonObject.put( StandardPropertyURN.DAMAGE.toString(),
        this.isDamageDefined() ? this.getDamage() : JSONObject.NULL );
    jsonObject.put( StandardPropertyURN.HP.toString(),
        this.isHPDefined() ? this.getHP() : JSONObject.NULL );
    jsonObject.put( StandardPropertyURN.POSITION.toString(),
        this.isPositionDefined() ? new int[]{ getX(), getY() }
            : JSONObject.NULL );
    jsonObject.put( StandardPropertyURN.POSITION_HISTORY.toString(),
        this.isPositionHistoryDefined() ? this.getPositionHistory()
            : JSONObject.NULL );

    return jsonObject;
  }
```

we handle getX() issues with check isDamageDefined. but I think we have a problem with rescuecore.

With these changes, We will not face any problem on WebView, and If one Entity has a problem, this Entity acts on this cycle will not be updated.
