### PR TITLE
Remove duplicate Entity IDs from getNeighbours output

### DIFF
--- a/modules/standard/src/rescuecore2/standard/entities/Area.java
+++ b/modules/standard/src/rescuecore2/standard/entities/Area.java
@@ -304,9 +304,9 @@ public abstract class Area extends StandardEntity {
    */
   public List<EntityID> getNeighbours() {
     if ( neighbours == null ) {
-      neighbours = new ArrayList<EntityID>();
+      neighbours = new ArrayList<>();
       for ( Edge next : edges.getValue() ) {
-        if ( next.isPassable() ) {
+        if ( next.isPassable() && !neighbours.contains( next.getNeighbour() ) ) {
           neighbours.add( next.getNeighbour() );
         }
       }


### PR DESCRIPTION
When two areas are connected by multiple edges (in maps like the `test` map), the `Area#getNeighbours()` output contains duplicate IDs referring to the same area.

I belive this output may not be correct. This PR modifies that function so that `Area#getNeighbours()` returns a list of unique IDs.