### PR TITLE
:sparkles: Add function to get edges to the neighbour

### DIFF
--- a/modules/standard/src/rescuecore2/standard/entities/Area.java
+++ b/modules/standard/src/rescuecore2/standard/entities/Area.java
@@ -1,9 +1,12 @@
 package rescuecore2.standard.entities;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.awt.Polygon;
 import java.awt.Shape;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.json.JSONObject;
 
@@ -330,6 +333,21 @@ public abstract class Area extends StandardEntity {
       }
     }
     return null;
+  }
+
+
+  /**
+   * Get the edges that cross to a particular neighbour.
+   *
+   * @param neighbour
+   *          The neighbour ID.
+   * @return A Set of all edges connecting to the given neighbour.
+   *         Returns an empty set if no such edges exist; this method never returns null.
+   */
+  public Set<Edge> getEdgesTo( EntityID neighbour ) {
+    return getEdges().stream()
+            .filter(edge -> neighbour.equals(edge.getNeighbour()))
+            .collect(Collectors.toUnmodifiableSet());
   }
 
 


### PR DESCRIPTION
Adds a new method `Area#getEdgesTo(EntityID neighbour)` to correctly retrieve all edges connecting to a specific neighbour.

The existing `getEdgeTo()` returns only the first found edge, which is insufficient for maps like "test" where areas can be connected by multiple edges. This can lead to incorrect geometric analysis.

The new `getEdgesTo()` method returns a `Set<Edge>` of all connecting edges, ensuring that no connection points are missed.