### PR TITLE
:bug: Resolve infinite loops and performance issues in conversion steps

### DIFF
--- a/modules/maps/src/maps/convert/osm2gml/DirectedEdge.java
+++ b/modules/maps/src/maps/convert/osm2gml/DirectedEdge.java
@@ -80,6 +80,15 @@ public class DirectedEdge {
     }
 
     /**
+     * Returns a new DirectedEdge that represents the same underlying edge
+     * but traversed in the opposite direction.
+     * @return A new DirectedEdge with the reverse direction.
+     */
+    public DirectedEdge getReverse() {
+        return new DirectedEdge(this.edge, !this.forward);
+    }
+
+    /**
        Get the coordinates of the start of this edge.
        @return The coordinates of the start of this edge.
      */

--- a/modules/maps/src/maps/convert/osm2gml/SpatialGrid.java
+++ b/modules/maps/src/maps/convert/osm2gml/SpatialGrid.java
@@ -1,0 +1,93 @@
+package maps.convert.osm2gml;
+
+import rescuecore2.misc.geometry.Line2D;
+import rescuecore2.misc.geometry.Point2D;
+
+import java.awt.geom.Rectangle2D;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class SpatialGrid {
+
+    private final Map<GridPoint, Set<Edge>> grid;
+    private final double cellWidth;
+    private final double cellHeight;
+    private final double minX;
+    private final double minY;
+
+    public SpatialGrid(Rectangle2D bounds, double cellSize) {
+        this.minX = bounds.getMinX();
+        this.minY = bounds.getMinY();
+        this.cellWidth = cellSize;
+        this.cellHeight = cellSize;
+        this.grid = new HashMap<>();
+    }
+
+    private record GridPoint(int x, int y) {}
+
+    private record CellBounds(int minX, int minY, int maxX, int maxY) {}
+
+    private CellBounds getEdgeCellBounds(Edge edge) {
+        Line2D line = edge.getLine();
+        Point2D start = line.getOrigin();
+        Point2D end = line.getEndPoint();
+
+        int startX = getXCell(start.getX());
+        int startY = getYCell(start.getY());
+        int endX = getXCell(end.getX());
+        int endY = getYCell(end.getY());
+
+        return new CellBounds(
+            Math.min(startX, endX),
+            Math.min(startY, endY),
+            Math.max(startX, endX),
+            Math.max(startY, endY)
+        );
+    }
+
+    public void add(Edge edge) {
+        CellBounds bounds = getEdgeCellBounds(edge);
+
+        for (int x = bounds.minX(); x <= bounds.maxX(); x++) {
+            for (int y = bounds.minY(); y <= bounds.maxY(); y++) {
+                addToCell(x, y, edge);
+            }
+        }
+    }
+
+    public Set<Edge> getNearbyEdges(Edge edge) {
+        Set<Edge> nearby = new HashSet<>();
+        CellBounds bounds = getEdgeCellBounds(edge);
+
+        // Search the 3x3 area around the edge's bounding box.
+        for (int x = bounds.minX() - 1; x <= bounds.maxX() + 1; x++) {
+            for (int y = bounds.minY() - 1; y <= bounds.maxY() + 1; y++) {
+                Set<Edge> cellContent = getFromCell(x, y);
+                if (cellContent != null) {
+                    nearby.addAll(cellContent);
+                }
+            }
+        }
+        return nearby;
+    }
+
+    private int getXCell(double x) {
+        return (int) Math.floor((x - minX) / cellWidth);
+    }
+
+    private int getYCell(double y) {
+        return (int) Math.floor((y - minY) / cellHeight);
+    }
+
+    private void addToCell(int x, int y, Edge edge) {
+        GridPoint key = new GridPoint(x, y);
+        grid.computeIfAbsent(key, k -> new HashSet<>()).add(edge);
+    }
+
+    private Set<Edge> getFromCell(int x, int y) {
+        return grid.get(new GridPoint(x, y));
+    }
+
+}

--- a/modules/maps/src/maps/convert/osm2gml/SplitIntersectingEdgesStep.java
+++ b/modules/maps/src/maps/convert/osm2gml/SplitIntersectingEdgesStep.java
@@ -1,10 +1,7 @@
 package maps.convert.osm2gml;
 
-import java.util.List;
-import java.util.Deque;
-import java.util.ArrayDeque;
-import java.util.Set;
-import java.util.HashSet;
+import java.awt.geom.Rectangle2D;
+import java.util.*;
 
 import rescuecore2.misc.geometry.Point2D;
 import rescuecore2.misc.geometry.Line2D;
@@ -17,10 +14,8 @@ import maps.convert.ConvertStep;
    This step splits any edges that intersect.
 */
 public class SplitIntersectingEdgesStep extends ConvertStep {
-    private TemporaryMap map;
+    private final TemporaryMap map;
     private int splitCount;
-    private int inspectedCount;
-    private Deque<Edge> toCheck;
     private Set<Edge> seen;
 
     /**
@@ -39,55 +34,114 @@ public class SplitIntersectingEdgesStep extends ConvertStep {
     @Override
     protected void step() {
         debug.setBackground(ConvertTools.getAllDebugShapes(map));
-        toCheck = new ArrayDeque<Edge>(map.getAllEdges());
-        seen = new HashSet<Edge>();
-        setProgressLimit(toCheck.size());
         splitCount = 0;
-        inspectedCount = 0;
-        while (!toCheck.isEmpty()) {
-            Edge next = toCheck.pop();
-            check(next);
-            ++inspectedCount;
-            setProgressLimit(toCheck.size() + inspectedCount);
-            bumpProgress();
+        int inspectedCount = 0;
+        int pass = 0;
+
+        while (true) {
+            pass++;
+            setStatus("Inspected " + inspectedCount + " edges and split " + splitCount);
+
+            List<Edge> edgeThisPass = new ArrayList<>(map.getAllEdges());
+            if (edgeThisPass.isEmpty()) break;
+
+            // Get bounds directly from the map.
+            Rectangle2D bounds = map.getBounds();
+
+            double averageDimension = (bounds.getWidth() + bounds.getHeight()) / 2.0;
+            double cellSizeInDegrees = averageDimension / 100.0;
+
+            // Handle cases where the map is tiny to avoid a cell size to zero.
+            if (cellSizeInDegrees < 1e-9) {
+                cellSizeInDegrees = 1e-9;
+            }
+
+            SpatialGrid grid = new SpatialGrid(bounds, cellSizeInDegrees);
+            for (Edge e : edgeThisPass) {
+                grid.add(e);
+            }
+
+            boolean anySplitInPass = false;
+            seen = new HashSet<>();
+            setProgressLimit(edgeThisPass.size());
+
+            for (int i = 0; i < edgeThisPass.size(); i++) {
+                Edge next = edgeThisPass.get(i);
+                Set<Edge> nearbyEdges = grid.getNearbyEdges(next);
+
+                if (check(next, nearbyEdges)) {
+                    anySplitInPass = true;
+                }
+
+                inspectedCount++;
+                setProgress(i + 1);
+            }
+
+            if (!anySplitInPass) {
+                break;
+            }
         }
-        setStatus("Inspected " + inspectedCount + " edges and split " + splitCount);
+
+        setStatus("Inspected " + inspectedCount + " edges and split " + splitCount + " times over " + pass + " passes");
     }
 
-    private void check(Edge e) {
-        if (!map.getAllEdges().contains(e)) {
-            //            Logger.debug("Skipped edge " + e);
-            //            debug.show("Skipped edge", new EdgeShapeInfo(e, "Skipped edge", Color.BLUE, true, false));
-            return;
-        }
-        if (seen.contains(e)) {
-            return;
+    private boolean check(Edge e, Set<Edge> candidates) {
+        if (!map.getAllEdges().contains(e) || seen.contains(e)) {
+            return false;
         }
         seen.add(e);
-        Line2D l1 = e.getLine();
-        Set<Edge> edges = new HashSet<Edge>(map.getAllEdges());
-        for (Edge test : edges) {
-            if (test.equals(e)) {
-                continue;
-            }
-            Line2D l2 = test.getLine();
-            if (GeometryTools2D.parallel(l1, l2)) {
-                if (processParallelLines(e, test)) {
+        boolean splitOccurred = false;
+
+        while (true) {
+            boolean mapChangedThisIteration = false;
+
+            for (Edge test : candidates) {
+                if (test.equals(e)) {
+                    continue;
+                }
+                if (!map.getAllEdges().contains(e)) {
+                    return splitOccurred;
+                }
+
+                boolean split = false;
+
+                Line2D l1 = e.getLine();
+                Line2D l2 = test.getLine();
+                if (GeometryTools2D.parallel(l1, l2)) {
+                    if (processParallelLines(e, test)) {
+                        split = true;
+                    }
+                } else {
+                    if (checkForIntersection(e, test)) {
+                        split = true;
+                    }
+                }
+
+                if (split) {
+                    mapChangedThisIteration = true;
+                    splitOccurred = true;
                     break;
                 }
             }
-            else {
-                if (checkForIntersection(e, test)) {
-                    break;
-                }
+
+            if (!mapChangedThisIteration) {
+                break;
             }
         }
+        return splitOccurred;
     }
 
     /**
        @return True if e1 was split.
     */
     private boolean processParallelLines(Edge e1, Edge e2) {
+        // If the two parallel lines already share an endpoint, they are considered
+        // connected, and we should not attempt to split them further.
+        if (e1.getStart().equals(e2.getStart()) || e1.getStart().equals(e2.getEnd())
+         || e1.getEnd().equals(e2.getStart()) || e2.getStart().equals(e1.getEnd())) {
+            return false; // Already connected, do nothing.
+        }
+
         // Possible cases:
         // Shorter line entirely inside longer
         // Shorter line overlaps longer at longer start
@@ -110,24 +164,20 @@ public class SplitIntersectingEdgesStep extends ConvertStep {
         boolean shortEndLongEnd = shorterEdge.getEnd() == longerEdge.getEnd();
         boolean startInside = !shortStartLongStart && !shortStartLongEnd && GeometryTools2D.contains(longer, shorter.getOrigin());
         boolean endInside = !shortEndLongStart && !shortEndLongEnd && GeometryTools2D.contains(longer, shorter.getEndPoint());
-        /*
-          if (startInside || endInside) {
-          ++overlapCount;
-          }
-        */
+
         if (startInside && endInside) {
             processInternalEdge(shorterEdge, longerEdge);
-            return longerEdge == e1;
+            return true;
         }
-        else if (startInside && !endInside) {
+        else if (startInside) {
             // Either full overlap or coincident end point
             if (shortEndLongStart) {
                 processCoincidentNode(shorterEdge, longerEdge, shorterEdge.getEnd());
-                return longerEdge == e1;
+                return true;
             }
             else if (shortEndLongEnd) {
                 processCoincidentNode(shorterEdge, longerEdge, shorterEdge.getEnd());
-                return longerEdge == e1;
+                return true;
             }
             else {
                 // Full overlap
@@ -135,15 +185,15 @@ public class SplitIntersectingEdgesStep extends ConvertStep {
                 return true;
             }
         }
-        else if (endInside && !startInside) {
+        else if (endInside) {
             // Either full overlap or coincident end point
             if (shortStartLongStart) {
                 processCoincidentNode(shorterEdge, longerEdge, shorterEdge.getStart());
-                return longerEdge == e1;
+                return true;
             }
             else if (shortStartLongEnd) {
                 processCoincidentNode(shorterEdge, longerEdge, shorterEdge.getStart());
-                return longerEdge == e1;
+                return true;
             }
             else {
                 // Full overlap
@@ -159,19 +209,11 @@ public class SplitIntersectingEdgesStep extends ConvertStep {
     */
     private boolean checkForIntersection(Edge first, Edge second) {
         Point2D intersection = GeometryTools2D.getSegmentIntersectionPoint(first.getLine(), second.getLine());
-        //                    System.out.println(intersection);
+
         if (intersection == null) {
             // Maybe the intersection is within the map's "nearby" tolerance?
-            intersection = GeometryTools2D.getIntersectionPoint(first.getLine(), second.getLine());
-            /*
-              debug.show("Split intersection",
-              new ShapeDebugFrame.Line2DShapeInfo(first, "Line 1", Color.ORANGE, true, false),
-              new ShapeDebugFrame.Line2DShapeInfo(second, "Line 2", Color.BLUE, true, false),
-              new ShapeDebugFrame.Point2DShapeInfo(intersection, "Near-miss intersection", Color.BLACK, false),
-              new ShapeDebugFrame.Line2DShapeInfo(firstObject.getLines(), "Object 1", Color.GREEN, false, false),
-              new ShapeDebugFrame.Line2DShapeInfo(secondObject.getLines(), "Object 2", Color.GRAY, false, false)
-              );
-            */
+            intersection = Objects.requireNonNull(GeometryTools2D.getIntersectionPoint(first.getLine(), second.getLine()));
+
             // Was this a near miss?
             if (map.isNear(intersection, first.getStart().getCoordinates()) || map.isNear(intersection, first.getEnd().getCoordinates())) {
                 // Check that the intersection is actually somewhere on the second segment
@@ -194,58 +236,31 @@ public class SplitIntersectingEdgesStep extends ConvertStep {
                 return false;
             }
         }
+
+        // If the intersection point is very close to an existing endpoint of either line.
+        if (map.isNear(intersection, first.getStart().getCoordinates())
+         || map.isNear(intersection, first.getEnd().getCoordinates())
+         || map.isNear(intersection, second.getStart().getCoordinates())
+         || map.isNear(intersection, second.getEnd().getCoordinates())) {
+            return false; // Already connected at an endpoint, no split needed.
+        }
+
         Node n = map.getNode(intersection);
         // Split the two edges into 4 (maybe)
         // Was the first edge split?
         boolean splitFirst = !n.equals(first.getStart()) && !n.equals(first.getEnd());
         boolean splitSecond = !n.equals(second.getStart()) && !n.equals(second.getEnd());
-        Set<Edge> newEdges = new HashSet<Edge>();
+
         if (splitFirst) {
-            List<Edge> e = map.splitEdge(first, n);
-            toCheck.addAll(e);
-            newEdges.addAll(e);
+            map.splitEdge(first, n);
             ++splitCount;
-            /*
-            Logger.debug("Split edge " + first);
-            debug.show("Split first line",
-                       new ShapeDebugFrame.Line2DShapeInfo(first.getLine(), "Line 1", Color.ORANGE, true, false),
-                       new EdgeShapeInfo(e, "New edges", Color.WHITE, false, true),
-                       new ShapeDebugFrame.Point2DShapeInfo(intersection, "Intersection", Color.BLACK, true)
-                       );
-            */
         }
         if (splitSecond) {
-            List<Edge> e = map.splitEdge(second, n);
-            toCheck.addAll(e);
-            newEdges.addAll(e);
+            map.splitEdge(second, n);
             ++splitCount;
-            /*
-            Logger.debug("Split edge " + second);
-            debug.show("Split second line",
-                       new ShapeDebugFrame.Line2DShapeInfo(second.getLine(), "Line 2", Color.BLUE, true, false),
-                       new EdgeShapeInfo(e, "New edges", Color.WHITE, false, true),
-                       new ShapeDebugFrame.Point2DShapeInfo(intersection, "Intersection", Color.BLACK, true)
-                       );
-            */
         }
-        //        if (splitFirst || splitSecond) {
-            /*
-            Logger.debug("First line: " + first + " -> " + first.getLine());
-            Logger.debug("Second line: " + second + " -> " + second.getLine());
-            Logger.debug("Intersection: " + intersection);
-            Logger.debug("New edges");
-            for (Edge next : newEdges) {
-                Logger.debug("  " + next + " -> " + next.getLine());
-            }
-            */
-            //            debug.show("Split intersection",
-            //                       new ShapeDebugFrame.Line2DShapeInfo(first.getLine(), "Line 1", Color.ORANGE, true, false),
-            //                       new ShapeDebugFrame.Line2DShapeInfo(second.getLine(), "Line 2", Color.BLUE, true, false),
-            //                       new EdgeShapeInfo(newEdges, "New edges", Color.WHITE, false, true),
-            //                       new ShapeDebugFrame.Point2DShapeInfo(intersection, "Intersection", Color.BLACK, true)
-            //                       );
-        //        }
-        return splitFirst;
+
+        return splitFirst || splitSecond;
     }
 
     private void processInternalEdge(Edge shorter, Edge longer) {
@@ -262,22 +277,22 @@ public class SplitIntersectingEdgesStep extends ConvertStep {
             first = shorter.getEnd();
             second = shorter.getStart();
         }
-        toCheck.addAll(map.splitEdge(longer, first, second));
+        map.splitEdge(longer, first, second);
         ++splitCount;
     }
 
     private void processCoincidentNode(Edge shorter, Edge longer, Node coincidentPoint) {
         // Split the long edge at the non-coincident point
         Node cutPoint = coincidentPoint.equals(shorter.getStart()) ? shorter.getEnd() : shorter.getStart();
-        toCheck.addAll(map.splitEdge(longer, cutPoint));
+        map.splitEdge(longer, cutPoint);
         ++splitCount;
     }
 
     private void processOverlap(Edge shorter, Edge longer) {
         Node shortSplit = GeometryTools2D.contains(shorter.getLine(), longer.getLine().getOrigin()) ? longer.getStart() : longer.getEnd();
         Node longSplit = GeometryTools2D.contains(longer.getLine(), shorter.getLine().getOrigin()) ? shorter.getStart() : shorter.getEnd();
-        toCheck.addAll(map.splitEdge(shorter, shortSplit));
-        toCheck.addAll(map.splitEdge(longer, longSplit));
+        map.splitEdge(shorter, shortSplit);
+        map.splitEdge(longer, longSplit);
         ++splitCount;
     }
 }

--- a/modules/maps/src/maps/gml/GMLMapFormat.java
+++ b/modules/maps/src/maps/gml/GMLMapFormat.java
@@ -69,15 +69,13 @@ public abstract class GMLMapFormat implements MapFormat {
         try {
             if (!file.exists()) {
                 File parent = file.getParentFile();
-                if (!parent.exists()) {
-                    if (!file.getParentFile().mkdirs()) {
+                if (parent != null && !parent.exists()) {
+                    if (!parent.mkdirs()) {
                         throw new MapException("Couldn't create file " + file.getPath());
                     }
                 }
-                if (!file.createNewFile()) {
-                    throw new MapException("Couldn't create file " + file.getPath());
-                }
             }
+
             XMLWriter writer = new XMLWriter(new FileOutputStream(file), OutputFormat.createPrettyPrint());
             Element root = doc.getRootElement();
             for (java.util.Map.Entry<String, String> next : getNamespaces().entrySet()) {


### PR DESCRIPTION
This PR fixes several critical bugs that caused the map conversion process to hang indefinitely. These issues were discovered while trying to convert the attached OSM file. The process would get stuck in `SplitIntersectionEdgesStep`.

OSM file used for testing:
https://drive.google.com/file/d/10oIiMRmjf7-O3ZVCvoZsYJj51XedsQLP/view?usp=sharing

Summary of the fixes:

1. Fixed Infinite Loops:

- `SplitIntersectingEdgesStep`: Resolved two infinite loops triggered by specific geometric in the OSM data.
  - An intersection loop occurred when an intersection point was extremely close to an existing node.
  - A parallel-lines loop occurred when parallel edges shared a common endpoint.
- `SplitShapesStep`: Fixed a subsequent loop where the algorithm would get stuck on "dangling edges" created after the initial splitting phase.

2. Improved Performance:

- To handle the high density of edges in the provided data, I've implemented a `SpatialGrid` index.
- This replaces the O(n^2) brute-force comparison with a much faster spatial query, only checking nearby edges for intersection. This essential for converting large or dense maps.

3. Fixed File Output Crash:

- Resolved a `NullPointerException` in `GMLMapFormat.write()`. This occurred when the output file was specified a **relative path that did not include a directory** (e.g. "output.gml"), causing `file.getParentFile()` to return `null`.

Let me know if you have any questions.