### PR TITLE
Ensure traversability of polygonal map objects by splitting concave shapes

### DIFF
--- a/modules/maps/src/maps/convert/osm2gml/Convertor.java
+++ b/modules/maps/src/maps/convert/osm2gml/Convertor.java
@@ -67,6 +67,7 @@ public class Convertor {
         addStep(new MergePassableShapesStep(temp), steps, progress, layout, c);
         addStep(new ConnectBuildingsStep(temp), steps, progress, layout, c);
         addStep(new PruneOrphanBuildingsStep(temp), steps, progress, layout, c);
+        addStep(new EnsureTraversabilityStep(temp), steps, progress, layout, c);
         addStep(new SplitIntersectingEdgesStep(temp), steps, progress, layout, c);
         addStep(new SplitShapesStep(temp), steps, progress, layout, c);
         addStep(new RemoveShapesStep(temp), steps, progress, layout, c);

--- a/modules/maps/src/maps/convert/osm2gml/DirectedEdge.java
+++ b/modules/maps/src/maps/convert/osm2gml/DirectedEdge.java
@@ -1,14 +1,16 @@
 package maps.convert.osm2gml;
 
+import lombok.Getter;
 import rescuecore2.misc.geometry.Point2D;
 import rescuecore2.misc.geometry.Line2D;
 
 /**
    A DirectedEdge is an edge with an orientation.
  */
+@Getter
 public class DirectedEdge {
-    private Edge edge;
-    private boolean forward;
+    private final Edge edge;
+    private final boolean forward;
     private Line2D line;
 
     /**
@@ -37,30 +39,6 @@ public class DirectedEdge {
         if (!forward) {
             line = new Line2D(line.getEndPoint(), line.getOrigin());
         }
-    }
-
-    /**
-       Get the underlying edge.
-       @return The underlying edge.
-     */
-    public Edge getEdge() {
-        return edge;
-    }
-
-    /**
-       Get the line represented by this edge.
-       @return The line.
-    */
-    public Line2D getLine() {
-        return line;
-    }
-
-    /**
-       Is this directed edge in the direction of the underlying edge?
-       @return True if this directed edge is aligned with the underlying edge direction, false otherwise.
-     */
-    public boolean isForward() {
-        return forward;
     }
 
     /**
@@ -126,8 +104,7 @@ public class DirectedEdge {
 
     @Override
     public boolean equals(Object o) {
-        if (o instanceof DirectedEdge) {
-            DirectedEdge e = (DirectedEdge)o;
+        if (o instanceof DirectedEdge e) {
             return this.forward == e.forward && this.edge.equals(e.edge);
         }
         return false;

--- a/modules/maps/src/maps/convert/osm2gml/EnsureTraversabilityStep.java
+++ b/modules/maps/src/maps/convert/osm2gml/EnsureTraversabilityStep.java
@@ -1,0 +1,299 @@
+package maps.convert.osm2gml;
+
+import rescuecore2.misc.geometry.GeometryTools2D;
+import rescuecore2.misc.geometry.Line2D;
+import rescuecore2.misc.geometry.Point2D;
+import rescuecore2.misc.geometry.Vector2D;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This step modify the map so that all shapes are traversable from their centroid.
+ */
+public class EnsureTraversabilityStep extends BaseModificationStep {
+    private final double threshold;
+    private static final int MAX_SPLIT_ITERATIONS = 5;
+
+    public EnsureTraversabilityStep(TemporaryMap map) {
+        super(map);
+        threshold = ConvertTools.sizeOfMeters(map.getOSMMap(), 1);
+    }
+
+
+    @Override
+    public String getDescription() {
+        return "Ensure shapes are traversable";
+    }
+
+    @Override
+    protected void step() {
+        int totalSplits = 0;
+        Collection<TemporaryObject> initialAllObjects = map.getAllObjects();
+        List<TemporaryObject> modifiedShapes = new ArrayList<>();
+        List<TemporaryObject> addedShapes = new ArrayList<>();
+
+        setProgressLimit(initialAllObjects.size());
+
+        for (TemporaryObject object : initialAllObjects) {
+
+            // Check if centroid can reach passable edges.
+            if (isValidObject(object)) continue;
+
+            ArrayDeque<TemporaryObject> toProcess = new ArrayDeque<>();
+            toProcess.offer(object);
+            modifiedShapes.add(object);
+
+            int iteration = 0;
+            while (!toProcess.isEmpty() && iteration < MAX_SPLIT_ITERATIONS) {
+                TemporaryObject current = toProcess.poll();
+                List<TemporaryObject> newShapes = splitObject(current);
+                totalSplits++;
+                iteration++;
+
+                for (TemporaryObject newObject : newShapes) {
+                    if (isValidObject(newObject)) {
+                        addedShapes.add(newObject);
+                    } else {
+                        toProcess.push(newObject);
+                    }
+                }
+            }
+
+            bumpProgress();
+        }
+
+        if (!modifiedShapes.isEmpty()) {
+            for (TemporaryObject object : modifiedShapes) map.removeTemporaryObject(object);
+            for (TemporaryObject object : addedShapes) map.addTemporaryObject(object);
+            map.resynchronizeStateFromObjects();
+        }
+
+        setStatus("Split " + totalSplits + " objects.");
+        visualizeDifference(modifiedShapes, addedShapes, "Splitting polygon");
+    }
+
+    private boolean isValidObject(TemporaryObject object) {
+        Point2D centroid = object.getCentroid();
+
+        // Skip shapes with fewer than 4 edges; triangles are always traversable.
+        List<DirectedEdge> edges = object.getEdges();
+        if (edges.size() < 4) return true;
+
+        // Separate edges into passable and impassable.
+        List<Line2D> passableLines = new ArrayList<>();
+        List<Line2D> impassableLines = new ArrayList<>();
+        for (DirectedEdge directedEdge : object.getEdges()) {
+            int attachedCount = map.getAttachedObjects(directedEdge.getEdge()).size();
+            if (1 < attachedCount) {
+                passableLines.add(directedEdge.getLine());
+            } else {
+                impassableLines.add(directedEdge.getLine());
+            }
+        }
+
+        for (Line2D line : passableLines) {
+            Point2D edgeCentre = line.getPoint(0.5);
+            Line2D lineOfSight = new Line2D(centroid, edgeCentre);
+            boolean intersects = intersectsAny(lineOfSight, impassableLines);
+            if (intersects) return false;
+        }
+
+        return true;
+    }
+
+    private List<TemporaryObject> splitObject(TemporaryObject object) {
+        List<Point2D> concavePoints = findConcaveVertices(object.getVertices());
+        List<Line2D> splitLines = generateSplitLines(object, concavePoints);
+        if (splitLines.isEmpty()) return Collections.emptyList();
+
+        double minConcaveCount = concavePoints.size();
+        Line2D bestSplitLine = null;
+        for (Line2D line : splitLines) {
+            List<Point2D> polygon = object.getVertices();
+            Point2D point1 = line.getOrigin();
+            Point2D point2 = line.getEndPoint();
+            List<List<Point2D>> splitPolygons = splitPolygon(polygon, point1, point2);
+            if (splitPolygons.size() != 2) continue;
+
+            double totalArea = GeometryTools2D.computeArea(polygon);
+            double area1 = GeometryTools2D.computeArea(splitPolygons.get(0));
+            double area2 = GeometryTools2D.computeArea(splitPolygons.get(1));
+
+            // Skip this line if it extends outside the original polygon.
+            if (threshold * threshold < area1 + area2 - totalArea) continue;
+
+            int concave1 = findConcaveVertices(splitPolygons.get(0)).size();
+            int concave2 = findConcaveVertices(splitPolygons.get(1)).size();
+            int totalConcaveCount = concave1 + concave2;
+
+            if (totalConcaveCount < minConcaveCount) {
+                minConcaveCount = totalConcaveCount;
+                bestSplitLine = line;
+            }
+        }
+
+        if (bestSplitLine == null) return Collections.emptyList();
+
+        Node startNode = findNode(object, bestSplitLine.getOrigin());
+        Node endNode = findNode(object, bestSplitLine.getEndPoint());
+
+        return splitObject(object, startNode, endNode);
+    }
+
+    private Node findNode(TemporaryObject object, Point2D point) {
+        List<Node> nodes = object.getNodes();
+        for (Node node : nodes) {
+            if (node.getCoordinates().equals(point)) return node;
+        }
+        return null;
+    }
+
+    private List<TemporaryObject> splitObject(TemporaryObject object, Node start, Node end) {
+        List<DirectedEdge> edges = object.getEdges();
+        List<DirectedEdge> path1 = getEdgesPath(edges, start, end);
+        List<DirectedEdge> path2 = getEdgesPath(edges, end, start);
+
+        TemporaryObject object1 = createTemporaryObject(object, path1);
+        TemporaryObject object2 = createTemporaryObject(object, path2);
+
+        if (object1 == null || object2 == null) return Collections.emptyList();
+
+        return List.of(object1, object2);
+    }
+
+    private List<DirectedEdge> getEdgesPath(List<DirectedEdge> edges, Node start, Node end) {
+        List<DirectedEdge> pathEdges = new ArrayList<>();
+        int n = edges.size();
+        boolean started = false;
+
+        for (int i = 0; i < n * 2; i++) {
+            DirectedEdge edge = edges.get(i % n);
+            if (edge.getStartNode().equals(start)) started = true;
+            if (started) pathEdges.add(edge);
+            if (edge.getEndNode().equals(end) && started) break;
+        }
+
+        // Close path.
+        Edge closeEdge = map.getEdge(end, start);
+        boolean isForward = closeEdge.getStart().equals(end);
+        pathEdges.add(new DirectedEdge(closeEdge, isForward));
+
+        return pathEdges;
+    }
+
+    private List<List<Point2D>> splitPolygon(List<Point2D> polygon, Point2D point1, Point2D point2) {
+        List<Point2D> path1 = getVerticesPath(polygon, point1, point2);
+        List<Point2D> path2 = getVerticesPath(polygon, point2, point1);
+
+        return List.of(path1, path2);
+    }
+
+    private List<Point2D> getVerticesPath(List<Point2D> vertices, Point2D start, Point2D end) {
+        List<Point2D> pathVertices = new ArrayList<>();
+        int n = vertices.size();
+        boolean started = false;
+
+        for (int i = 0; i < n * 2; i++) {
+            Point2D vertex = vertices.get(i % n);
+            if (vertex.equals(start)) started = true;
+            if (started) pathVertices.add(vertex);
+            if (vertex.equals(end) && started) break;
+        }
+        pathVertices.add(start); // Close path.
+
+        return pathVertices;
+    }
+
+    private List<Point2D> findConcaveVertices(List<Point2D> vertices) {
+        List<Point2D> concaveVertices = new ArrayList<>();
+        int n = vertices.size();
+        boolean isCounterclockwise = GeometryTools2D.isCounterClockwise(vertices);
+
+        for (int i = 0; i < n; i++) {
+            Point2D prevVertex = vertices.get((i - 1 + n) % n);
+            Point2D currVertex = vertices.get(i);
+            Point2D nextVertex = vertices.get((i + 1) % n);
+
+            Vector2D vector1 = currVertex.minus(prevVertex);
+            Vector2D vector2 = nextVertex.minus(currVertex);
+            double cross = vector1.cross(vector2);
+            double squaredThreshold = threshold * threshold;
+            if (isCounterclockwise && cross < -squaredThreshold || !isCounterclockwise && squaredThreshold < cross) {
+                concaveVertices.add(currVertex);
+            }
+        }
+
+        return concaveVertices;
+    }
+
+    private static List<Line2D> generateSplitLines(TemporaryObject object, List<Point2D> concaveVertices) {
+        List<Line2D> splitLines = new ArrayList<>();
+        List<Point2D> polygonVertices = object.getVertices();
+        int n = polygonVertices.size();
+
+        for (Point2D concaveVertex : concaveVertices) {
+            int index = polygonVertices.indexOf(concaveVertex);
+            int prev = (index - 1 + n) % n;
+            int next = (index + 1) % n;
+
+            for (int i = 0; i < polygonVertices.size(); i++) {
+                if (i == index || i == prev || i == next) continue;
+
+                Point2D candidateVertex = polygonVertices.get(i);
+                Line2D line = new Line2D(concaveVertex, candidateVertex);
+                Line2D reverseLine = new Line2D(candidateVertex, concaveVertex);
+
+                if (splitLines.contains(line) || splitLines.contains(reverseLine)) continue;
+
+                splitLines.add(line);
+            }
+        }
+        return splitLines;
+    }
+
+    // Create a new TemporaryObject of the same type as the original, using provided edges.
+    private TemporaryObject createTemporaryObject(TemporaryObject original, List<DirectedEdge> path) {
+        if (path.isEmpty()) return null;
+
+        List<DirectedEdge> edgesCopy = new ArrayList<>(path);
+
+        if (original instanceof TemporaryRoad) {
+            return new TemporaryRoad(edgesCopy);
+        } else if (original instanceof TemporaryIntersection) {
+            return new TemporaryIntersection(edgesCopy);
+        } else if (original instanceof TemporaryBuilding building) {
+            return new TemporaryBuilding(edgesCopy, building.getBuildingID());
+        } else {
+            return null;
+        }
+    }
+
+    // Check if a given line intersects with any line in a collection.
+    private boolean intersectsAny(Line2D line, Collection<Line2D> others) {
+        for (Line2D other : others) {
+            if (crosses(line, other)) return true;
+        }
+        return false;
+    }
+
+    // Check if two line segments properly cross each other (excluding touching at endpoints).
+    private boolean crosses(Line2D line1, Line2D line2) {
+        // Compute intersection parameters along each line
+        double intersection1 = line1.getIntersection(line2);
+        double intersection2 = line2.getIntersection(line1);
+
+        // If lines are parallel, they do not have a valid intersection.
+        if (Double.isNaN(intersection1) || Double.isNaN(intersection2)) return false;
+
+        // Define a small threshold to avoid counting endpoints as crossings.
+        boolean isInternal1 = threshold < intersection1 && intersection1 < (1.0 - threshold);
+        boolean isInternal2 = threshold < intersection2 && intersection2 < (1.0 - threshold);
+
+        return isInternal1 && isInternal2;
+    }
+
+}

--- a/modules/rescuecore2/src/rescuecore2/misc/geometry/GeometryTools2D.java
+++ b/modules/rescuecore2/src/rescuecore2/misc/geometry/GeometryTools2D.java
@@ -233,6 +233,40 @@ public final class GeometryTools2D {
     }
 
     /**
+     * Compute the signed area of a simple polygon.
+     * The sigh of the area indicates the orientation of the vertices:
+     * positive if counter-clockwise, negative if clockwise.
+     * @param vertices The vertices of the polygon in order.
+     * @return The signed area of the polygon. Positive for counter-clockwise orientation.
+     */
+    public static double computeSignedArea(List<Point2D> vertices) {
+        // Shift all vertices so that the first vertex becomes the origin (0,0).
+        // This improves numerical stability when computing the polygon area.
+        List<Point2D> shiftedVertices = translate(vertices, vertices.get(0).toVector().negate());
+
+        Iterator<Point2D> it = shiftedVertices.iterator();
+        Point2D last = it.next();
+        Point2D first = last;
+        double sum = 0;
+        while (it.hasNext()) {
+            Point2D next = it.next();
+            double lastX = last.getX();
+            double lastY = last.getY();
+            double nextX = next.getX();
+            double nextY = next.getY();
+            sum += (lastX * nextY) - (nextX * lastY);
+            last = next;
+        }
+        double lastX = last.getX();
+        double lastY = last.getY();
+        double nextX = first.getX();
+        double nextY = first.getY();
+        sum += (lastX * nextY) - (nextX * lastY);
+        sum /= 2.0;
+        return sum;
+    }
+
+    /**
        Compute the centroid of a simple polygon.
        @param vertices The vertices of the polygon.
        @return The centroid.
@@ -274,6 +308,17 @@ public final class GeometryTools2D {
 
         // Translate the centroid back to the original coordinate system.
         return new Point2D(xSum, ySum).plus(shiftVector);
+    }
+
+    /**
+     * Check if the vertices of a polygon are ordered in a counter-clockwise direction.
+     * This is determined by the sign of the signed area of the polygon.
+     * A positive area corresponds to a counter-clockwise ordering.
+     * @param vertices The vertices of the polygon.
+     * @return true if the vertices are in counter-clockwise order, false otherwise.
+     */
+    public static boolean isCounterClockwise(List<Point2D> vertices) {
+        return 0 < computeSignedArea(vertices);
     }
 
     /**
@@ -446,33 +491,6 @@ public final class GeometryTools2D {
             return null;
         }
         return new Line2D(line.getPoint(tMin), line.getPoint(tMax));
-    }
-
-    private static double computeSignedArea(List<Point2D> vertices) {
-        // Shift all vertices so that the first vertex becomes the origin (0,0).
-        // This improves numerical stability when computing the polygon area.
-        List<Point2D> shiftedVertices = translate(vertices, vertices.get(0).toVector().negate());
-
-        Iterator<Point2D> it = shiftedVertices.iterator();
-        Point2D last = it.next();
-        Point2D first = last;
-        double sum = 0;
-        while (it.hasNext()) {
-            Point2D next = it.next();
-            double lastX = last.getX();
-            double lastY = last.getY();
-            double nextX = next.getX();
-            double nextY = next.getY();
-            sum += (lastX * nextY) - (nextX * lastY);
-            last = next;
-        }
-        double lastX = last.getX();
-        double lastY = last.getY();
-        double nextX = first.getX();
-        double nextY = first.getY();
-        sum += (lastX * nextY) - (nextX * lastY);
-        sum /= 2.0;
-        return sum;
     }
 
     /**

--- a/modules/rescuecore2/src/rescuecore2/misc/geometry/Point2D.java
+++ b/modules/rescuecore2/src/rescuecore2/misc/geometry/Point2D.java
@@ -74,6 +74,14 @@ public class Point2D implements Indexable {
     return new Point2D(this.x + v.getX(), this.y + v.getY());
   }
 
+  /**
+   * Convert this point into a vector from the origin.
+   * @return A Vector2D from (0,0) to this point.
+   */
+  public Vector2D toVector() {
+    return new Vector2D(x, y);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof Point2D)) {

--- a/modules/rescuecore2/src/rescuecore2/misc/geometry/Vector2D.java
+++ b/modules/rescuecore2/src/rescuecore2/misc/geometry/Vector2D.java
@@ -4,8 +4,8 @@ package rescuecore2.misc.geometry;
    A vector in 2D space. Points are immutable.
  */
 public class Vector2D {
-    private double dx;
-    private double dy;
+    private final double dx;
+    private final double dy;
     private double length;
 
     /**
@@ -37,6 +37,15 @@ public class Vector2D {
      */
     public double dot(Vector2D v) {
         return dx * v.dx + dy * v.dy;
+    }
+
+    /**
+     * Calculate the cross product of this vector and another vector.
+     * @param v The other vector.
+     * @return The cross product of this vector and the other vector.
+     */
+    public double cross(Vector2D v) {
+        return dx * v.dy - dy * v.dx;
     }
 
     /**
@@ -79,6 +88,14 @@ public class Vector2D {
      */
     public Vector2D normalised() {
         return scale(1.0 / getLength());
+    }
+
+    /**
+     * Get the opposite of this vector.
+     * @return A new Vector2D with both components negated.
+     */
+    public Vector2D negate() {
+        return new Vector2D(-dx, -dy);
     }
 
     /**


### PR DESCRIPTION
This PR introduces a new step (`EnsureTraversabilityStep`) that ensures all polygonal shapes in the map are traversable from their centroid.

- Added an algorithm that detects concave vertices and generates candidate split lines.
- Recursively splits polygons along lines that reduce the number of concave vertices.
- Each resulting sub-polygon is validated using the same traversability checks as in `gmlEdgitor`

Before this improvements:
<img width="477" height="463" alt="image" src="https://github.com/user-attachments/assets/2045c280-6f80-47a4-ade7-79b449f642f2" />

After this improvements:
<img width="476" height="376" alt="image" src="https://github.com/user-attachments/assets/776d5ccc-fe19-4234-8257-536790bc35f8" />
