### PR TITLE
Display all editor tools as icons

### DIFF
--- a/modules/gis2/src/gis2/scenario/AgentOverlay.java
+++ b/modules/gis2/src/gis2/scenario/AgentOverlay.java
@@ -13,15 +13,16 @@ import maps.gml.view.Overlay;
 import rescuecore2.misc.collections.LazyMap;
 import rescuecore2.misc.gui.ScreenTransform;
 
+import static gis2.scenario.EntityColours.AMBULANCE_TEAM_COLOUR;
+import static gis2.scenario.EntityColours.CIVILIAN_COLOUR;
+import static gis2.scenario.EntityColours.FIRE_BRIGADE_COLOUR;
+import static gis2.scenario.EntityColours.POLICE_FORCE_COLOUR;
+
 /**
  * Overlay for viewing agents in a scenario.
  */
 public class AgentOverlay implements Overlay {
   private static final int SIZE = 11;
-  private static final Color CIVILIAN_COLOUR = Color.GREEN;
-  private static final Color FIRE_BRIGADE_COLOUR = Color.RED;
-  private static final Color POLICE_FORCE_COLOUR = Color.BLUE;
-  private static final Color AMBULANCE_TEAM_COLOUR = Color.WHITE;
   private static final int OFFSET = 7;
   private ScenarioEditor editor;
 

--- a/modules/gis2/src/gis2/scenario/EntityColours.java
+++ b/modules/gis2/src/gis2/scenario/EntityColours.java
@@ -1,0 +1,36 @@
+package gis2.scenario;
+
+import java.awt.Color;
+
+/**
+ * Defines colour constants for rendering entities in the scenario editor.
+ * This is a utility class and cannot be instantiated.
+ */
+public class EntityColours {
+
+    /** The colour for civilians. */
+    public static final Color CIVILIAN_COLOUR         = Color.GREEN;
+    /** The colour for fire brigades. */
+    public static final Color FIRE_BRIGADE_COLOUR     = Color.RED;
+    /** The colour for ambulance teams. */
+    public static final Color AMBULANCE_TEAM_COLOUR   = Color.WHITE;
+    /** The colour for police forces. */
+    public static final Color POLICE_FORCE_COLOUR     = Color.BLUE;
+    /** The colour for fire stations. */
+    public static final Color FIRE_STATION_COLOUR     = new Color(255, 255,   0);
+    /** The colour for ambulance centres. */
+    public static final Color AMBULANCE_CENTRE_COLOUR = new Color(255, 255, 255);
+    /** The colour for police offices. */
+    public static final Color POLICE_OFFICE_COLOUR    = new Color(  0,   0, 255);
+    /** The colour for refuges. */
+    public static final Color REFUGE_COLOUR           = new Color(  0, 128,   0);
+    /** The colour for fires. */
+    public static final Color FIRE_COLOUR             = new Color(255,   0,   0, 128);
+    /** The colour for gas stations. */
+    public static final Color GAS_STATION_COLOUR      = new Color(255, 128,   0);
+    /** The colour for hydrants. */
+    public static final Color HYDRANT_COLOUR          = new Color(128, 128,   0);
+
+    private EntityColours() {}
+
+}

--- a/modules/gis2/src/gis2/scenario/PlaceAmbulanceCentreTool.java
+++ b/modules/gis2/src/gis2/scenario/PlaceAmbulanceCentreTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class PlaceAmbulanceCentreTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place ambulance centre";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_AMBULANCE_CENTRE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/PlaceAmbulanceTeamTool.java
+++ b/modules/gis2/src/gis2/scenario/PlaceAmbulanceTeamTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLShape;
@@ -20,6 +21,11 @@ public class PlaceAmbulanceTeamTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place ambulance team";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_AMBULANCE_TEAM;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/PlaceCivilianTool.java
+++ b/modules/gis2/src/gis2/scenario/PlaceCivilianTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLShape;
@@ -20,6 +21,11 @@ public class PlaceCivilianTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place civilian";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_CIVILIAN;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/PlaceFireBrigadeTool.java
+++ b/modules/gis2/src/gis2/scenario/PlaceFireBrigadeTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLShape;
@@ -20,6 +21,11 @@ public class PlaceFireBrigadeTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place fire brigade";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_FIRE_BRIGADE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/PlaceFireStationTool.java
+++ b/modules/gis2/src/gis2/scenario/PlaceFireStationTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class PlaceFireStationTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place fire station";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_FIRE_STATION;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/PlaceFireTool.java
+++ b/modules/gis2/src/gis2/scenario/PlaceFireTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class PlaceFireTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place fire";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_FIRE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/PlaceGasStationTool.java
+++ b/modules/gis2/src/gis2/scenario/PlaceGasStationTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class PlaceGasStationTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place gas station";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_GAS_STATION;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/PlaceHydrantTool.java
+++ b/modules/gis2/src/gis2/scenario/PlaceHydrantTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLRoad;
@@ -21,6 +22,11 @@ public class PlaceHydrantTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place hydrant";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_HYDRANT;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/PlacePoliceForceTool.java
+++ b/modules/gis2/src/gis2/scenario/PlacePoliceForceTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLShape;
@@ -20,6 +21,11 @@ public class PlacePoliceForceTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place police force";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_POLICE_FORCE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/PlacePoliceOfficeTool.java
+++ b/modules/gis2/src/gis2/scenario/PlacePoliceOfficeTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class PlacePoliceOfficeTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place police office";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_POLICE_OFFICE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/PlaceRefugeTool.java
+++ b/modules/gis2/src/gis2/scenario/PlaceRefugeTool.java
@@ -2,6 +2,7 @@ package gis2.scenario;
 
 import java.awt.GridLayout;
 
+import javax.swing.Icon;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -27,6 +28,11 @@ public class PlaceRefugeTool extends ShapeTool {
   @Override
   public String getName() {
     return "Place refuge";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.PLACE_REFUGE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemoveAmbulanceCentreTool.java
+++ b/modules/gis2/src/gis2/scenario/RemoveAmbulanceCentreTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class RemoveAmbulanceCentreTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove ambulance centre";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_AMBULANCE_CENTRE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemoveAmbulanceTeamTool.java
+++ b/modules/gis2/src/gis2/scenario/RemoveAmbulanceTeamTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLShape;
@@ -20,6 +21,11 @@ public class RemoveAmbulanceTeamTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove ambulance team";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_AMBULANCE_TEAM;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemoveCivilianTool.java
+++ b/modules/gis2/src/gis2/scenario/RemoveCivilianTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLShape;
@@ -20,6 +21,11 @@ public class RemoveCivilianTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove civilian";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_CIVILIAN;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemoveFireBrigadeTool.java
+++ b/modules/gis2/src/gis2/scenario/RemoveFireBrigadeTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLShape;
@@ -20,6 +21,11 @@ public class RemoveFireBrigadeTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove fire brigade";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_FIRE_BRIGADE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemoveFireStationTool.java
+++ b/modules/gis2/src/gis2/scenario/RemoveFireStationTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class RemoveFireStationTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove fire station";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_FIRE_STATION;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemoveFireTool.java
+++ b/modules/gis2/src/gis2/scenario/RemoveFireTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class RemoveFireTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove fire";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_FIRE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemoveGasStationTool.java
+++ b/modules/gis2/src/gis2/scenario/RemoveGasStationTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class RemoveGasStationTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove gas station";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_GAS_STATION;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemoveHydrantTool.java
+++ b/modules/gis2/src/gis2/scenario/RemoveHydrantTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLRoad;
@@ -21,6 +22,11 @@ public class RemoveHydrantTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove hydrant";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_HYDRANT;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemovePoliceForceTool.java
+++ b/modules/gis2/src/gis2/scenario/RemovePoliceForceTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLShape;
@@ -20,6 +21,11 @@ public class RemovePoliceForceTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove police force";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_POLICE_FORCE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemovePoliceOfficeTool.java
+++ b/modules/gis2/src/gis2/scenario/RemovePoliceOfficeTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class RemovePoliceOfficeTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove police office";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_POLICE_OFFICE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/RemoveRefugeTool.java
+++ b/modules/gis2/src/gis2/scenario/RemoveRefugeTool.java
@@ -1,5 +1,6 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
 import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLBuilding;
@@ -21,6 +22,11 @@ public class RemoveRefugeTool extends ShapeTool {
   @Override
   public String getName() {
     return "Remove refuge";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ToolIcons.REMOVE_REFUGE;
   }
 
   @Override

--- a/modules/gis2/src/gis2/scenario/ScenarioEditor.java
+++ b/modules/gis2/src/gis2/scenario/ScenarioEditor.java
@@ -25,7 +25,6 @@ import javax.swing.JMenuBar;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.SwingUtilities;
@@ -43,7 +42,6 @@ import maps.gml.GMLRefuge;
 import maps.gml.view.DecoratorOverlay;
 import maps.gml.view.FilledShapeDecorator;
 import maps.gml.view.GMLMapViewer;
-import maps.gml.view.GMLObjectInspector;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
@@ -57,12 +55,8 @@ import rescuecore2.config.Config;
  */
 public class ScenarioEditor extends JPanel {
 
-  private static final int PREFERRED_WIDTH           = 800;
-  private static final int PREFERRED_HEIGHT          = 600;
-  private static final int PREFERRED_VIEWER_WIDTH    = 400;
-  private static final int PREFERRED_INSPECTOR_WIDTH = 400;
-
-  private static final double SPLIT_RATE = 0.5;
+  private static final int PREFERRED_WIDTH  = 1280;
+  private static final int PREFERRED_HEIGHT =  800;
 
   private static final Color FIRE_STATION_COLOUR     = new Color(255, 255,   0);
   private static final Color AMBULANCE_CENTRE_COLOUR = new Color(255, 255, 255);
@@ -77,7 +71,6 @@ public class ScenarioEditor extends JPanel {
   private Tool currentTool;
 
   @Getter private final GMLMapViewer viewer;
-  private final GMLObjectInspector inspector;
   private final JLabel statusLabel;
 
   private final DecoratorOverlay fireOverlay;
@@ -127,22 +120,18 @@ public class ScenarioEditor extends JPanel {
     this.map = map;
     this.scenario = scenario;
 
-    viewer = new GMLMapViewer(map);
-    viewer.setPreferredSize(new Dimension(PREFERRED_VIEWER_WIDTH, PREFERRED_HEIGHT));
-    viewer.setPaintNodes(false);
 
     fireOverlay = new DecoratorOverlay();
     centreOverlay = new DecoratorOverlay();
     AgentOverlay agentOverlay = new AgentOverlay(this);
 
+    viewer = new GMLMapViewer(map);
+    viewer.setPaintNodes(false);
     viewer.addOverlay(fireOverlay);
     viewer.addOverlay(centreOverlay);
     viewer.addOverlay(agentOverlay);
     viewer.setBackground(Color.GRAY);
     viewer.getPanZoomListener().setPanOnRightMouse();
-
-    inspector = new GMLObjectInspector(map);
-    inspector.setPreferredSize(new Dimension(PREFERRED_INSPECTOR_WIDTH, PREFERRED_HEIGHT));
 
     statusLabel = new JLabel("Status");
 
@@ -161,10 +150,6 @@ public class ScenarioEditor extends JPanel {
     createFileActions(fileMenu, fileToolbar);
     createEditActions(editMenu, editToolbar);
     createFunctionActions(functionsMenu, functionsToolbar);
-
-    JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, viewer, inspector);
-    split.setResizeWeight(SPLIT_RATE);
-    add(split, BorderLayout.CENTER);
 
     JToolBar toolbar = new JToolBar();
     toolbar.setFloatable(false);
@@ -189,6 +174,7 @@ public class ScenarioEditor extends JPanel {
             JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
             JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 
+    add(viewer, BorderLayout.CENTER);
     add(toolBarScroll, BorderLayout.NORTH);
     add(toolPanelScroll, BorderLayout.WEST);
     add(statusLabel, BorderLayout.SOUTH);
@@ -228,7 +214,6 @@ public class ScenarioEditor extends JPanel {
     frame.pack();
     frame.setPreferredSize(new Dimension(PREFERRED_WIDTH, PREFERRED_HEIGHT));
     frame.addWindowListener(new WindowAdapter() {
-
       @Override
       public void windowClosing(WindowEvent e) {
         try {
@@ -374,7 +359,6 @@ public class ScenarioEditor extends JPanel {
     scenario = newScenario;
     changed = false;
     viewer.setMap(map);
-    inspector.setMap(map);
     updateOverlays();
   }
 

--- a/modules/gis2/src/gis2/scenario/ScenarioEditor.java
+++ b/modules/gis2/src/gis2/scenario/ScenarioEditor.java
@@ -645,7 +645,7 @@ public class ScenarioEditor extends JPanel {
   private void addTool(final Tool t, JMenu menu, JToolBar toolbar, ButtonGroup menuGroup, ButtonGroup toolbarGroup) {
     final JToggleButton toggle = new JToggleButton();
     final JCheckBoxMenuItem check = new JCheckBoxMenuItem();
-    Action action = new AbstractAction(t.getName()) {
+    final Action action = new AbstractAction(t.getName()) {
       @Override
       public void actionPerformed(ActionEvent e) {
         if (currentTool != null) {
@@ -657,8 +657,12 @@ public class ScenarioEditor extends JPanel {
         currentTool.activate();
       }
     };
-    toggle.setAction(action);
+    action.putValue(Action.SMALL_ICON, t.getIcon());
+    action.putValue(Action.SHORT_DESCRIPTION, t.getName());
     check.setAction(action);
+    toggle.setAction(action);
+//    toggle.setMaximumSize(new Dimension(300, 30));
+    toggle.setText("");
     menu.add(check);
     toolbar.add(toggle);
     menuGroup.add(check);

--- a/modules/gis2/src/gis2/scenario/ScenarioEditor.java
+++ b/modules/gis2/src/gis2/scenario/ScenarioEditor.java
@@ -34,6 +34,8 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.undo.CannotUndoException;
 import javax.swing.undo.UndoManager;
 import javax.swing.undo.UndoableEdit;
+
+import lombok.Getter;
 import maps.MapException;
 import maps.MapReader;
 import maps.gml.GMLMap;
@@ -55,53 +57,49 @@ import rescuecore2.config.Config;
  */
 public class ScenarioEditor extends JPanel {
 
-  private static final int PREFERRED_WIDTH = 800;
-  private static final int PREFERRED_HEIGHT = 600;
-  private static final int PREFERRED_VIEWER_WIDTH = 400;
+  private static final int PREFERRED_WIDTH           = 800;
+  private static final int PREFERRED_HEIGHT          = 600;
+  private static final int PREFERRED_VIEWER_WIDTH    = 400;
   private static final int PREFERRED_INSPECTOR_WIDTH = 400;
+
   private static final double SPLIT_RATE = 0.5;
 
-  private static final Color FIRE_COLOUR = new Color(255, 0, 0, 128);
-  private static final Color FIRE_STATION_COLOUR = new Color(255, 255, 0);
-  private static final Color POLICE_OFFICE_COLOUR = new Color(0, 0, 255);
+  private static final Color FIRE_STATION_COLOUR     = new Color(255, 255,   0);
   private static final Color AMBULANCE_CENTRE_COLOUR = new Color(255, 255, 255);
-  private static final Color REFUGE_COLOUR = new Color(0, 128, 0);
-  private static final Color HYDRANT_COLOUR = new Color(128, 128, 0);
-  private static final Color GAS_STATION_COLOUR = new Color(255, 128, 0);
+  private static final Color POLICE_OFFICE_COLOUR    = new Color(  0,   0, 255);
+  private static final Color REFUGE_COLOUR           = new Color(  0, 128,   0);
+  private static final Color FIRE_COLOUR             = new Color(255,   0,   0, 128);
+  private static final Color GAS_STATION_COLOUR      = new Color(255, 128,   0);
+  private static final Color HYDRANT_COLOUR          = new Color(128, 128,   0);
 
-  private GMLMap map;
-  private GMLMapViewer viewer;
-  private GMLObjectInspector inspector;
-  private DecoratorOverlay fireOverlay;
-  private DecoratorOverlay centreOverlay;
-  private transient AgentOverlay agentOverlay;
-  private GisScenario scenario;
+  @Getter private GMLMap map;
+  @Getter private GisScenario scenario;
   private Tool currentTool;
-  private JLabel statusLabel;
+
+  @Getter private final GMLMapViewer viewer;
+  private final GMLObjectInspector inspector;
+  private final JLabel statusLabel;
+
+  private final DecoratorOverlay fireOverlay;
+  private final DecoratorOverlay centreOverlay;
 
   private boolean changed;
 
-  private UndoManager undoManager;
+  private final UndoManager undoManager;
   private transient Action undoAction;
   private transient Action redoAction;
 
   private File baseDir;
   private File saveFile;
 
-  private FilledShapeDecorator fireDecorator = new FilledShapeDecorator(
-      FIRE_COLOUR, null, null);
-  private FilledShapeDecorator fireStationDecorator = new FilledShapeDecorator(
-      FIRE_STATION_COLOUR, null, null);
-  private FilledShapeDecorator policeOfficeDecorator = new FilledShapeDecorator(
-      POLICE_OFFICE_COLOUR, null, null);
-  private FilledShapeDecorator ambulanceCentreDecorator = new FilledShapeDecorator(
-      AMBULANCE_CENTRE_COLOUR, null, null);
-  private FilledShapeDecorator refugeDecorator = new FilledShapeDecorator(
-      REFUGE_COLOUR, null, null);
-  private FilledShapeDecorator gasStationDecorator = new FilledShapeDecorator(
-      GAS_STATION_COLOUR, null, null);
-  private FilledShapeDecorator hydrantDecorator = new FilledShapeDecorator(null,
-      HYDRANT_COLOUR, null);
+  private final FilledShapeDecorator fireDecorator         = new FilledShapeDecorator(FIRE_COLOUR, null, null);
+  private final FilledShapeDecorator fireStationDecorator  = new FilledShapeDecorator(FIRE_STATION_COLOUR, null, null);
+  private final FilledShapeDecorator policeOfficeDecorator = new FilledShapeDecorator(POLICE_OFFICE_COLOUR, null, null);
+
+  private final FilledShapeDecorator ambulanceCentreDecorator = new FilledShapeDecorator(AMBULANCE_CENTRE_COLOUR, null, null);
+  private final FilledShapeDecorator refugeDecorator          = new FilledShapeDecorator(REFUGE_COLOUR, null, null);
+  private final FilledShapeDecorator gasStationDecorator      = new FilledShapeDecorator(GAS_STATION_COLOUR, null, null);
+  private final FilledShapeDecorator hydrantDecorator         = new FilledShapeDecorator(null, HYDRANT_COLOUR, null);
 
   /**
    * Construct a new ScenarioEditor.
@@ -135,7 +133,7 @@ public class ScenarioEditor extends JPanel {
 
     fireOverlay = new DecoratorOverlay();
     centreOverlay = new DecoratorOverlay();
-    agentOverlay = new AgentOverlay(this);
+    AgentOverlay agentOverlay = new AgentOverlay(this);
 
     viewer.addOverlay(fireOverlay);
     viewer.addOverlay(centreOverlay);
@@ -214,16 +212,12 @@ public class ScenarioEditor extends JPanel {
     final JFrame frame = new JFrame("Scenario Editor");
     JMenuBar menuBar = new JMenuBar();
     final ScenarioEditor editor = new ScenarioEditor(menuBar);
-    if (args.length > 0 && args[0].length() > 0) {
+    if (args.length > 0 && !args[0].isEmpty()) {
       try {
         editor.load(args[0]);
       } catch (CancelledByUserException e) {
         return;
-      } catch (MapException e) {
-        e.printStackTrace();
-      } catch (ScenarioException e) {
-        e.printStackTrace();
-      } catch (rescuecore2.scenario.exceptions.ScenarioException e) {
+      } catch (MapException | ScenarioException | rescuecore2.scenario.exceptions.ScenarioException e) {
         e.printStackTrace();
       }
     }
@@ -394,27 +388,6 @@ public class ScenarioEditor extends JPanel {
     }
   }
 
-
-  /**
-   * Get the map.
-   *
-   * @return The map.
-   */
-  public GMLMap getMap() {
-    return map;
-  }
-
-
-  /**
-   * Get the scenario.
-   *
-   * @return The scenario.
-   */
-  public GisScenario getScenario() {
-    return scenario;
-  }
-
-
   /**
    * Save the scenario.
    *
@@ -453,7 +426,6 @@ public class ScenarioEditor extends JPanel {
     }
   }
 
-
   /**
    * Save the scenario.
    *
@@ -468,38 +440,15 @@ public class ScenarioEditor extends JPanel {
     }
   }
 
-
   /**
    * Close the editor.
    *
    * @throws CancelledByUserException
-   *   If the user cancels the close due to unsaved
-   *   changes."
+   *   If the user cancels the close due to unsaved changes.
    */
   public void close() throws CancelledByUserException {
     checkForChanges();
   }
-
-
-  /**
-   * Get the map viewer.
-   *
-   * @return The map viewer.
-   */
-  public GMLMapViewer getViewer() {
-    return viewer;
-  }
-
-
-  /**
-   * Get the object inspector.
-   *
-   * @return The object inspector.
-   */
-  public GMLObjectInspector getInspector() {
-    return inspector;
-  }
-
 
   /**
    * Register a change to the map.
@@ -507,7 +456,6 @@ public class ScenarioEditor extends JPanel {
   public void setChanged() {
     changed = true;
   }
-
 
   /**
    * Register an undoable edit.
@@ -521,7 +469,6 @@ public class ScenarioEditor extends JPanel {
     redoAction.setEnabled(undoManager.canRedo());
   }
 
-
   /**
    * Update the overlay views.
    */
@@ -533,7 +480,6 @@ public class ScenarioEditor extends JPanel {
     updateStatusLabel();
     viewer.repaint();
   }
-
 
   private void checkForChanges() throws CancelledByUserException {
     if (changed) {
@@ -561,7 +507,6 @@ public class ScenarioEditor extends JPanel {
       }
     }
   }
-
 
   private void createFileActions(JMenu menu, JToolBar toolbar) {
     Action newAction = new AbstractAction("New") {
@@ -622,7 +567,6 @@ public class ScenarioEditor extends JPanel {
     menu.add(saveAsAction);
   }
 
-
   private void createEditActions(JMenu menu, JToolBar toolbar) {
     undoAction = new AbstractAction("Undo") {
 
@@ -658,56 +602,6 @@ public class ScenarioEditor extends JPanel {
     menu.add(redoAction);
   }
 
-
-  private void createToolActions(JMenu menu, JToolBar toolbar) {
-    ButtonGroup toolbarGroup = new ButtonGroup();
-    ButtonGroup menuGroup = new ButtonGroup();
-    addTool(new PlaceCivilianTool(this), menu, toolbar, menuGroup,
-            toolbarGroup);
-    addTool(new RemoveCivilianTool(this), menu, toolbar, menuGroup,
-            toolbarGroup);
-    addTool(new PlaceFireBrigadeTool(this), menu, toolbar, menuGroup,
-        toolbarGroup);
-    addTool(new RemoveFireBrigadeTool(this), menu, toolbar, menuGroup,
-        toolbarGroup);
-    addTool(new PlaceAmbulanceTeamTool(this), menu, toolbar, menuGroup,
-        toolbarGroup);
-    addTool(new RemoveAmbulanceTeamTool(this), menu, toolbar, menuGroup,
-        toolbarGroup);
-    addTool(new PlacePoliceForceTool(this), menu, toolbar, menuGroup,
-            toolbarGroup);
-    addTool(new RemovePoliceForceTool(this), menu, toolbar, menuGroup,
-            toolbarGroup);
-    menu.addSeparator();
-    toolbar.addSeparator();
-    addTool(new PlaceFireStationTool(this), menu, toolbar, menuGroup,
-        toolbarGroup);
-    addTool(new RemoveFireStationTool(this), menu, toolbar, menuGroup,
-        toolbarGroup);
-    addTool(new PlaceAmbulanceCentreTool(this), menu, toolbar, menuGroup,
-        toolbarGroup);
-    addTool(new RemoveAmbulanceCentreTool(this), menu, toolbar, menuGroup,
-        toolbarGroup);
-    addTool(new PlacePoliceOfficeTool(this), menu, toolbar, menuGroup,
-            toolbarGroup);
-    addTool(new RemovePoliceOfficeTool(this), menu, toolbar, menuGroup,
-            toolbarGroup);
-    menu.addSeparator();
-    toolbar.addSeparator();
-    addTool(new PlaceRefugeTool(this), menu, toolbar, menuGroup, toolbarGroup);
-    addTool(new RemoveRefugeTool(this), menu, toolbar, menuGroup, toolbarGroup);
-    addTool(new PlaceGasStationTool(this), menu, toolbar, menuGroup,
-            toolbarGroup);
-    addTool(new RemoveGasStationTool(this), menu, toolbar, menuGroup,
-            toolbarGroup);
-    addTool(new PlaceHydrantTool(this), menu, toolbar, menuGroup, toolbarGroup);
-    addTool(new RemoveHydrantTool(this), menu, toolbar, menuGroup,
-            toolbarGroup);
-    addTool(new PlaceFireTool(this), menu, toolbar, menuGroup, toolbarGroup);
-    addTool(new RemoveFireTool(this), menu, toolbar, menuGroup, toolbarGroup);
-  }
-
-
   private void createFunctionActions(JMenu menu, JToolBar toolbar) {
     addFunction(new RandomiseFunction(this), menu, toolbar);
     addFunction(new ClearFiresFunction(this), menu, toolbar);
@@ -717,13 +611,57 @@ public class ScenarioEditor extends JPanel {
     addFunction(new RandomHydrantPlacementFunction(this), menu, toolbar);
   }
 
+  private void createToolActions(JMenu menu, JToolBar toolbar) {
+    ButtonGroup toolbarGroup = new ButtonGroup();
+    ButtonGroup menuGroup = new ButtonGroup();
 
-  private void addTool(final Tool t, JMenu menu, JToolBar toolbar,
-      ButtonGroup menuGroup, ButtonGroup toolbarGroup) {
+    addTool(new PlaceCivilianTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemoveCivilianTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new PlaceFireBrigadeTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemoveFireBrigadeTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new PlaceAmbulanceTeamTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemoveAmbulanceTeamTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new PlacePoliceForceTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemovePoliceForceTool(this), menu, toolbar, menuGroup, toolbarGroup);
+
+    menu.addSeparator();
+    toolbar.addSeparator();
+
+    addTool(new PlaceFireStationTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemoveFireStationTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new PlaceAmbulanceCentreTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemoveAmbulanceCentreTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new PlacePoliceOfficeTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemovePoliceOfficeTool(this), menu, toolbar, menuGroup, toolbarGroup);
+
+    menu.addSeparator();
+    toolbar.addSeparator();
+
+    addTool(new PlaceRefugeTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemoveRefugeTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new PlaceGasStationTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemoveGasStationTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new PlaceHydrantTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemoveHydrantTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new PlaceFireTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemoveFireTool(this), menu, toolbar, menuGroup, toolbarGroup);
+  }
+
+  private void addFunction(final Function f, JMenu menu, JToolBar toolbar) {
+    Action action = new AbstractAction(f.getName()) {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        f.execute();
+      }
+    };
+    toolbar.add(action);
+    menu.add(action);
+  }
+
+  private void addTool(final Tool t, JMenu menu, JToolBar toolbar, ButtonGroup menuGroup, ButtonGroup toolbarGroup) {
     final JToggleButton toggle = new JToggleButton();
     final JCheckBoxMenuItem check = new JCheckBoxMenuItem();
     Action action = new AbstractAction(t.getName()) {
-
       @Override
       public void actionPerformed(ActionEvent e) {
         if (currentTool != null) {
@@ -742,20 +680,6 @@ public class ScenarioEditor extends JPanel {
     menuGroup.add(check);
     toolbarGroup.add(toggle);
   }
-
-
-  private void addFunction(final Function f, JMenu menu, JToolBar toolbar) {
-    Action action = new AbstractAction(f.getName()) {
-
-      @Override
-      public void actionPerformed(ActionEvent e) {
-        f.execute();
-      }
-    };
-    toolbar.add(action);
-    menu.add(action);
-  }
-
 
   private boolean checkScenario(GMLMap newMap, GisScenario newScenario) {
     boolean valid = true;
@@ -813,27 +737,19 @@ public class ScenarioEditor extends JPanel {
     return valid;
   }
 
-
   private void updateStatusLabel() {
-    SwingUtilities.invokeLater(new Runnable() {
-
-      @Override
-      public void run() {
-        statusLabel.setText(scenario.getFires().size() + " fires, "
-            + scenario.getRefuges().size() + " refuges, "
-            + scenario.getHydrants().size() + " hydrants, "
-            + scenario.getGasStations().size() + " gas stations, "
-            + scenario.getCivilians().size() + " civilians, "
-            + scenario.getFireBrigades().size() + " fb, "
-            + scenario.getFireStations().size() + " fs, "
-            + scenario.getPoliceForces().size() + " pf, "
-            + scenario.getPoliceOffices().size() + " po, "
-            + scenario.getAmbulanceTeams().size() + " at, "
-            + scenario.getAmbulanceCentres().size() + " ac");
-      }
-    });
+    SwingUtilities.invokeLater(() -> statusLabel.setText(scenario.getFires().size() + " fires, "
+        + scenario.getRefuges().size() + " refuges, "
+        + scenario.getHydrants().size() + " hydrants, "
+        + scenario.getGasStations().size() + " gas stations, "
+        + scenario.getCivilians().size() + " civilians, "
+        + scenario.getFireBrigades().size() + " fb, "
+        + scenario.getFireStations().size() + " fs, "
+        + scenario.getPoliceForces().size() + " pf, "
+        + scenario.getPoliceOffices().size() + " po, "
+        + scenario.getAmbulanceTeams().size() + " at, "
+        + scenario.getAmbulanceCentres().size() + " ac"));
   }
-
 
   private void updateFireOverlay() {
     fireOverlay.clearAllBuildingDecorators();
@@ -841,7 +757,6 @@ public class ScenarioEditor extends JPanel {
       fireOverlay.setBuildingDecorator(fireDecorator, map.getBuilding(next));
     }
   }
-
 
   private void updateCentreOverlay() {
     centreOverlay.clearAllBuildingDecorators();
@@ -872,7 +787,5 @@ public class ScenarioEditor extends JPanel {
     }
   }
 
-
-  private void updateAgentOverlay() {
-  }
+  private void updateAgentOverlay() {}
 }

--- a/modules/gis2/src/gis2/scenario/ScenarioEditor.java
+++ b/modules/gis2/src/gis2/scenario/ScenarioEditor.java
@@ -50,6 +50,14 @@ import org.dom4j.io.SAXReader;
 import org.dom4j.io.XMLWriter;
 import rescuecore2.config.Config;
 
+import static gis2.scenario.EntityColours.AMBULANCE_CENTRE_COLOUR;
+import static gis2.scenario.EntityColours.FIRE_COLOUR;
+import static gis2.scenario.EntityColours.FIRE_STATION_COLOUR;
+import static gis2.scenario.EntityColours.GAS_STATION_COLOUR;
+import static gis2.scenario.EntityColours.HYDRANT_COLOUR;
+import static gis2.scenario.EntityColours.POLICE_OFFICE_COLOUR;
+import static gis2.scenario.EntityColours.REFUGE_COLOUR;
+
 /**
  * A component for editing scenarios.
  */
@@ -57,14 +65,6 @@ public class ScenarioEditor extends JPanel {
 
   private static final int PREFERRED_WIDTH  = 1280;
   private static final int PREFERRED_HEIGHT =  800;
-
-  private static final Color FIRE_STATION_COLOUR     = new Color(255, 255,   0);
-  private static final Color AMBULANCE_CENTRE_COLOUR = new Color(255, 255, 255);
-  private static final Color POLICE_OFFICE_COLOUR    = new Color(  0,   0, 255);
-  private static final Color REFUGE_COLOUR           = new Color(  0, 128,   0);
-  private static final Color FIRE_COLOUR             = new Color(255,   0,   0, 128);
-  private static final Color GAS_STATION_COLOUR      = new Color(255, 128,   0);
-  private static final Color HYDRANT_COLOUR          = new Color(128, 128,   0);
 
   @Getter private GMLMap map;
   @Getter private GisScenario scenario;
@@ -623,12 +623,12 @@ public class ScenarioEditor extends JPanel {
 
     addTool(new PlaceRefugeTool(this), menu, toolbar, menuGroup, toolbarGroup);
     addTool(new RemoveRefugeTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new PlaceFireTool(this), menu, toolbar, menuGroup, toolbarGroup);
+    addTool(new RemoveFireTool(this), menu, toolbar, menuGroup, toolbarGroup);
     addTool(new PlaceGasStationTool(this), menu, toolbar, menuGroup, toolbarGroup);
     addTool(new RemoveGasStationTool(this), menu, toolbar, menuGroup, toolbarGroup);
     addTool(new PlaceHydrantTool(this), menu, toolbar, menuGroup, toolbarGroup);
     addTool(new RemoveHydrantTool(this), menu, toolbar, menuGroup, toolbarGroup);
-    addTool(new PlaceFireTool(this), menu, toolbar, menuGroup, toolbarGroup);
-    addTool(new RemoveFireTool(this), menu, toolbar, menuGroup, toolbarGroup);
   }
 
   private void addFunction(final Function f, JMenu menu, JToolBar toolbar) {

--- a/modules/gis2/src/gis2/scenario/Tool.java
+++ b/modules/gis2/src/gis2/scenario/Tool.java
@@ -1,5 +1,7 @@
 package gis2.scenario;
 
+import javax.swing.Icon;
+
 /**
  * Interface for a scenario editing tool.
  */
@@ -10,6 +12,13 @@ public interface Tool {
    * @return The name of the tool.
    */
   String getName();
+
+  /**
+   * Get the icon of this tool.
+   *
+   * @return The icon of the tool.
+   */
+  Icon getIcon();
 
   /**
    * Activate this tool.

--- a/modules/gis2/src/gis2/scenario/ToolIcons.java
+++ b/modules/gis2/src/gis2/scenario/ToolIcons.java
@@ -1,0 +1,204 @@
+package gis2.scenario;
+
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+
+import static gis2.scenario.EntityColours.AMBULANCE_CENTRE_COLOUR;
+import static gis2.scenario.EntityColours.AMBULANCE_TEAM_COLOUR;
+import static gis2.scenario.EntityColours.CIVILIAN_COLOUR;
+import static gis2.scenario.EntityColours.FIRE_BRIGADE_COLOUR;
+import static gis2.scenario.EntityColours.FIRE_COLOUR;
+import static gis2.scenario.EntityColours.FIRE_STATION_COLOUR;
+import static gis2.scenario.EntityColours.GAS_STATION_COLOUR;
+import static gis2.scenario.EntityColours.HYDRANT_COLOUR;
+import static gis2.scenario.EntityColours.POLICE_FORCE_COLOUR;
+import static gis2.scenario.EntityColours.POLICE_OFFICE_COLOUR;
+import static gis2.scenario.EntityColours.REFUGE_COLOUR;
+
+public class ToolIcons {
+
+    private static final int ICON_SIZE = 16;
+    private static final Color HUMAN_STROKE_COLOUR = new Color(160, 160, 160);
+    private static final Color AREA_STROKE_COLOUR  = Color.BLACK;
+    private static final Color REMOVE_MARK_COLOUR  = Color.BLACK;
+
+    public static final Icon PLACE_CIVILIAN          = createPlaceCivilianIcon();
+    public static final Icon PLACE_FIRE_BRIGADE      = createPlaceFireBrigadeIcon();
+    public static final Icon PLACE_AMBULANCE_TEAM    = createPlaceAmbulanceTeamIcon();
+    public static final Icon PLACE_POLICE_FORCE      = createPlacePoliceForceIcon();
+    public static final Icon PLACE_FIRE_STATION      = createPlaceFireStationIcon();
+    public static final Icon PLACE_AMBULANCE_CENTRE  = createPlaceAmbulanceCentreIcon();
+    public static final Icon PLACE_POLICE_OFFICE     = createPlacePoliceOfficeIcon();
+    public static final Icon PLACE_REFUGE            = createPlaceRefugeIcon();
+    public static final Icon PLACE_GAS_STATION       = createPlaceGasStationIcon();
+    public static final Icon PLACE_HYDRANT           = createPlaceHydrantIcon();
+    public static final Icon PLACE_FIRE              = createPlaceFireIcon();
+
+    public static final Icon REMOVE_CIVILIAN         = createRemoveCivilianIcon();
+    public static final Icon REMOVE_FIRE_BRIGADE     = createRemoveFireBrigadeIcon();
+    public static final Icon REMOVE_AMBULANCE_TEAM   = createRemoveAmbulanceTeamIcon();
+    public static final Icon REMOVE_POLICE_FORCE     = createRemovePoliceForceIcon();
+    public static final Icon REMOVE_FIRE_STATION     = createRemoveFireStationIcon();
+    public static final Icon REMOVE_AMBULANCE_CENTRE = createRemoveAmbulanceCentreIcon();
+    public static final Icon REMOVE_POLICE_OFFICE    = createRemovePoliceOfficeIcon();
+    public static final Icon REMOVE_REFUGE           = createRemoveRefugeIcon();
+    public static final Icon REMOVE_GAS_STATION      = createRemoveGasStationIcon();
+    public static final Icon REMOVE_HYDRANT          = createRemoveHydrantIcon();
+    public static final Icon REMOVE_FIRE             = createRemoveFireIcon();
+
+    private ToolIcons() {}
+
+    private static Icon createPlaceCivilianIcon() {
+        return createPlaceHumanIcon(CIVILIAN_COLOUR);
+    }
+
+    private static Icon createPlaceFireBrigadeIcon() {
+        return createPlaceHumanIcon(FIRE_BRIGADE_COLOUR);
+    }
+
+    private static Icon createPlaceAmbulanceTeamIcon() {
+        return createPlaceHumanIcon(AMBULANCE_TEAM_COLOUR);
+    }
+
+    private static Icon createPlacePoliceForceIcon() {
+        return createPlaceHumanIcon(POLICE_FORCE_COLOUR);
+    }
+
+    private static Icon createPlaceFireStationIcon() {
+        return createPlaceAreaIcon(FIRE_STATION_COLOUR);
+    }
+
+    private static Icon createPlaceAmbulanceCentreIcon() {
+        return createPlaceAreaIcon(AMBULANCE_CENTRE_COLOUR);
+    }
+
+    private static Icon createPlacePoliceOfficeIcon() {
+        return createPlaceAreaIcon(POLICE_OFFICE_COLOUR);
+    }
+
+    private static Icon createPlaceRefugeIcon() {
+        return createPlaceAreaIcon(REFUGE_COLOUR);
+    }
+
+    private static Icon createPlaceGasStationIcon() {
+        return createPlaceAreaIcon(GAS_STATION_COLOUR);
+    }
+
+    private static Icon createPlaceHydrantIcon() {
+        return createPlaceAreaIcon(HYDRANT_COLOUR);
+    }
+
+    private static Icon createPlaceFireIcon() {
+        return createPlaceAreaIcon(FIRE_COLOUR);
+    }
+
+    private static Icon createRemoveCivilianIcon() {
+        return createRemoveHumanIcon(CIVILIAN_COLOUR);
+    }
+
+    private static Icon createRemoveFireBrigadeIcon() {
+        return createRemoveHumanIcon(FIRE_BRIGADE_COLOUR);
+    }
+
+    private static Icon createRemoveAmbulanceTeamIcon() {
+        return createRemoveHumanIcon(AMBULANCE_TEAM_COLOUR);
+    }
+
+    private static Icon createRemovePoliceForceIcon() {
+        return createRemoveHumanIcon(POLICE_FORCE_COLOUR);
+    }
+
+    private static Icon createRemoveFireStationIcon() {
+        return createRemoveAreaIcon(FIRE_STATION_COLOUR);
+    }
+
+    private static Icon createRemoveAmbulanceCentreIcon() {
+        return createRemoveAreaIcon(AMBULANCE_CENTRE_COLOUR);
+    }
+
+    private static Icon createRemovePoliceOfficeIcon() {
+        return createRemoveAreaIcon(POLICE_OFFICE_COLOUR);
+    }
+
+    private static Icon createRemoveRefugeIcon() {
+        return createRemoveAreaIcon(REFUGE_COLOUR);
+    }
+
+    private static Icon createRemoveGasStationIcon() {
+        return createRemoveAreaIcon(GAS_STATION_COLOUR);
+    }
+
+    private static Icon createRemoveHydrantIcon() {
+        return createRemoveAreaIcon(HYDRANT_COLOUR);
+    }
+
+    private static Icon createRemoveFireIcon() {
+        return createRemoveAreaIcon(FIRE_COLOUR);
+    }
+
+    private static Icon createPlaceHumanIcon(Color colour) {
+        BufferedImage image = new BufferedImage(ICON_SIZE, ICON_SIZE, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        drawHumanIcon(g2d, colour);
+        g2d.dispose();
+        return new ImageIcon(image);
+    }
+
+    private static Icon createPlaceAreaIcon(Color colour) {
+        BufferedImage image = new BufferedImage(ICON_SIZE, ICON_SIZE, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        drawAreaIcon(g2d, colour);
+        g2d.dispose();
+        return new ImageIcon(image);
+    }
+
+    private static Icon createRemoveHumanIcon(Color colour) {
+        BufferedImage image = new BufferedImage(ICON_SIZE, ICON_SIZE, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        drawHumanIcon(g2d, colour);
+        drawRemoveMark(g2d);
+        g2d.dispose();
+        return new ImageIcon(image);
+    }
+
+    private static Icon createRemoveAreaIcon(Color colour) {
+        BufferedImage image = new BufferedImage(ICON_SIZE, ICON_SIZE, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        drawAreaIcon(g2d, colour);
+        drawRemoveMark(g2d);
+        g2d.dispose();
+        return new ImageIcon(image);
+    }
+
+    private static void drawHumanIcon(Graphics2D g2d, Color colour) {
+        g2d.setColor(colour);
+        g2d.fillOval(1, 1, ICON_SIZE - 2, ICON_SIZE - 2);
+        g2d.setColor(HUMAN_STROKE_COLOUR);
+        g2d.setStroke(new BasicStroke(2));
+        g2d.drawOval(1, 1, ICON_SIZE - 2, ICON_SIZE - 2);
+    }
+
+    private static void drawAreaIcon(Graphics2D g2d, Color colour) {
+        g2d.setColor(colour);
+        g2d.fillRect(1, 1, ICON_SIZE - 3, ICON_SIZE - 3);
+        g2d.setColor(AREA_STROKE_COLOUR);
+        g2d.setStroke(new BasicStroke(1));
+        g2d.drawRect(1, 1, ICON_SIZE - 3, ICON_SIZE - 3);
+    }
+
+    private static void drawRemoveMark(Graphics2D g2d) {
+        g2d.setColor(REMOVE_MARK_COLOUR);
+        g2d.setStroke(new BasicStroke(2));
+        g2d.drawLine(0, 0, ICON_SIZE, ICON_SIZE);
+    }
+
+}


### PR DESCRIPTION
This PR replaces text-based tool buttons on  the toolbar with icons.
The original tool names are now displayed as tooltips.

Image of the new icon-based toolbar:
<img width="921" height="773" alt="image" src="https://github.com/user-attachments/assets/daecd895-558c-43f4-ad9a-405505e5a861" />
