### PR TITLE
:sparkles: Add a function to clear all agents of a specific type

### DIFF
--- a/modules/gis2/src/gis2/GisScenario.java
+++ b/modules/gis2/src/gis2/GisScenario.java
@@ -567,9 +567,27 @@ public class GisScenario implements rescuecore2.scenario.Scenario, CollapseSimCo
 
   /**
    * Set the set of refuge locations.
+   * This method updates the set of refuge locations and their bed capacities.
    *
    * @param newLocations The new set of locations.
    */
+  public void setRefuges(Map<Integer, Integer> newLocations) {
+    refuges.clear();
+    refugeBedCapacity.clear();
+    refuges.addAll(newLocations.keySet());
+    refugeBedCapacity.putAll(newLocations);
+
+    // The following block is retained for backward compatibility:
+    refugeRefillCapacity.clear();
+    newLocations.keySet().forEach(location -> refugeRefillCapacity.put(location, 1000));
+  }
+
+  /**
+   * Set the set of refuge locations.
+   *
+   * @param newLocations The new set of locations.
+   */
+  @Deprecated
   public void setRefuges(Set<Integer> newLocations) {
     refuges.clear();
     refuges.addAll(newLocations);
@@ -883,6 +901,37 @@ public class GisScenario implements rescuecore2.scenario.Scenario, CollapseSimCo
    */
   public void removeAmbulanceCentre(int location) {
     acLocations.remove(location);
+  }
+
+  /**
+   * Clear all agents.
+   */
+  public void clearAgents() {
+    fbLocations.clear();
+    atLocations.clear();
+    pfLocations.clear();
+    fsLocations.clear();
+    acLocations.clear();
+    poLocations.clear();
+  }
+
+  /**
+   * Clear all fires.
+   */
+  public void clearFires() {
+    fires.clear();
+  }
+
+  /**
+   * Clear all scenario data.
+   */
+  public void clearAll() {
+    civLocations.clear();
+    clearAgents();
+    refuges.clear();
+    hydrants.clear();
+    gasStations.clear();
+    clearFires();
   }
 
   private void setupAgent(Human h, EntityID position, StandardWorldModel model, Config config)

--- a/modules/gis2/src/gis2/GisScenario.java
+++ b/modules/gis2/src/gis2/GisScenario.java
@@ -904,15 +904,31 @@ public class GisScenario implements rescuecore2.scenario.Scenario, CollapseSimCo
   }
 
   /**
-   * Clear all agents.
+   * Clear all civilians.
    */
-  public void clearAgents() {
+  public void clearCivilians() {
+    civLocations.clear();
+  }
+
+  /**
+   * Clear all fire brigades.
+   */
+  public void clearFireBrigades() {
     fbLocations.clear();
+  }
+
+  /**
+   * Clear all ambulance teams.
+   */
+  public void clearAmbulanceTeams() {
     atLocations.clear();
+  }
+
+  /**
+   * Clear all police forces.
+   */
+  public void clearPoliceForces() {
     pfLocations.clear();
-    fsLocations.clear();
-    acLocations.clear();
-    poLocations.clear();
   }
 
   /**
@@ -923,10 +939,22 @@ public class GisScenario implements rescuecore2.scenario.Scenario, CollapseSimCo
   }
 
   /**
+   * Clear all agents.
+   */
+  public void clearAgents() {
+    clearFireBrigades();
+    clearAmbulanceTeams();
+    clearPoliceForces();
+    fsLocations.clear();
+    acLocations.clear();
+    poLocations.clear();
+  }
+
+  /**
    * Clear all scenario data.
    */
   public void clearAll() {
-    civLocations.clear();
+    clearCivilians();
     clearAgents();
     refuges.clear();
     hydrants.clear();

--- a/modules/gis2/src/gis2/scenario/ClearAgentsFunction.java
+++ b/modules/gis2/src/gis2/scenario/ClearAgentsFunction.java
@@ -2,7 +2,7 @@ package gis2.scenario;
 
 import gis2.GisScenario;
 
-import java.util.HashSet;
+import javax.swing.undo.AbstractUndoableEdit;
 
 /**
  * Function for removing all agents.
@@ -19,19 +19,40 @@ public class ClearAgentsFunction extends AbstractFunction {
 
   @Override
   public String getName() {
-    return "Remove agents";
+    return "Remove Agents";
   }
 
   @Override
   public void execute() {
-    GisScenario s = editor.getScenario();
-    s.setFireBrigades(new HashSet<Integer>());
-    s.setFireStations(new HashSet<Integer>());
-    s.setPoliceForces(new HashSet<Integer>());
-    s.setPoliceOffices(new HashSet<Integer>());
-    s.setAmbulanceTeams(new HashSet<Integer>());
-    s.setAmbulanceCentres(new HashSet<Integer>());
+    GisScenario scenario = editor.getScenario();
+    ScenarioSnapshot snapshot = new ScenarioSnapshot(scenario);
+    ClearAgentsEdit clearEdit = new ClearAgentsEdit(snapshot);
+
+    scenario.clearAgents();
     editor.setChanged();
     editor.updateOverlays();
+    editor.addEdit(clearEdit);
+  }
+
+  private class ClearAgentsEdit extends AbstractUndoableEdit {
+    private final ScenarioSnapshot snapshot;
+
+    public ClearAgentsEdit(ScenarioSnapshot snapshot) {
+      this.snapshot = snapshot;
+    }
+
+    @Override
+    public void undo() {
+      super.undo();
+      snapshot.restore(editor.getScenario());
+      editor.updateOverlays();
+    }
+
+    @Override
+    public void redo() {
+      super.redo();
+      editor.getScenario().clearAgents();
+      editor.updateOverlays();
+    }
   }
 }

--- a/modules/gis2/src/gis2/scenario/ClearAllFunction.java
+++ b/modules/gis2/src/gis2/scenario/ClearAllFunction.java
@@ -2,7 +2,7 @@ package gis2.scenario;
 
 import gis2.GisScenario;
 
-import java.util.HashSet;
+import javax.swing.undo.AbstractUndoableEdit;
 
 /**
  * Function for removing all agents, fires, civilians and refuges.
@@ -19,24 +19,40 @@ public class ClearAllFunction extends AbstractFunction {
 
   @Override
   public String getName() {
-    return "Remove all";
+    return "Remove All";
   }
 
   @Override
   public void execute() {
-    GisScenario s = editor.getScenario();
-    s.setFireBrigades(new HashSet<Integer>());
-    s.setFireStations(new HashSet<Integer>());
-    s.setPoliceForces(new HashSet<Integer>());
-    s.setPoliceOffices(new HashSet<Integer>());
-    s.setAmbulanceTeams(new HashSet<Integer>());
-    s.setAmbulanceCentres(new HashSet<Integer>());
-    s.setCivilians(new HashSet<Integer>());
-    s.setFires(new HashSet<Integer>());
-    s.setRefuges(new HashSet<Integer>());
-    s.setGasStations(new HashSet<Integer>());
-    s.setHydrants(new HashSet<Integer>());
+    GisScenario scenario = editor.getScenario();
+    ScenarioSnapshot snapshot = new ScenarioSnapshot(scenario);
+    ClearAllEdit clearEdit = new ClearAllEdit(snapshot);
+
+    scenario.clearAll();
     editor.setChanged();
     editor.updateOverlays();
+    editor.addEdit(clearEdit);
+  }
+
+  private class ClearAllEdit extends AbstractUndoableEdit {
+    private final ScenarioSnapshot snapshot;
+
+    public ClearAllEdit(ScenarioSnapshot snapshot) {
+      this.snapshot = snapshot;
+    }
+
+    @Override
+    public void undo() {
+      super.undo();
+      snapshot.restore(editor.getScenario());
+      editor.updateOverlays();
+    }
+
+    @Override
+    public void redo() {
+      super.redo();
+      editor.getScenario().clearAgents();
+      editor.updateOverlays();
+    }
   }
 }

--- a/modules/gis2/src/gis2/scenario/ClearAmbulanceTeamsFunction.java
+++ b/modules/gis2/src/gis2/scenario/ClearAmbulanceTeamsFunction.java
@@ -1,0 +1,58 @@
+package gis2.scenario;
+
+import gis2.GisScenario;
+
+import javax.swing.undo.AbstractUndoableEdit;
+
+/**
+ * Function for removing all ambulance teams.
+ */
+public class ClearAmbulanceTeamsFunction extends AbstractFunction {
+    /**
+     * Construct a clear ambulance teams function.
+     *
+     * @param editor The editor instance.
+     */
+    public ClearAmbulanceTeamsFunction(ScenarioEditor editor) {
+        super(editor);
+    }
+
+    @Override
+    public String getName() {
+        return "Remove Ambulance Teams";
+    }
+
+    @Override
+    public void execute() {
+        GisScenario scenario = editor.getScenario();
+        ScenarioSnapshot snapshot = new ScenarioSnapshot(scenario);
+        ClearAmbulanceTeamsEdit clearEdit = new ClearAmbulanceTeamsEdit(snapshot);
+
+        scenario.clearAmbulanceTeams();
+        editor.setChanged();
+        editor.updateOverlays();
+        editor.addEdit(clearEdit);
+    }
+
+    private class ClearAmbulanceTeamsEdit extends AbstractUndoableEdit {
+        private final ScenarioSnapshot snapshot;
+
+        public ClearAmbulanceTeamsEdit(ScenarioSnapshot snapshot) {
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public void undo() {
+            super.undo();
+            snapshot.restore(editor.getScenario());
+            editor.updateOverlays();
+        }
+
+        @Override
+        public void redo() {
+            super.redo();
+            editor.getScenario().clearAmbulanceTeams();
+            editor.updateOverlays();
+        }
+    }
+}

--- a/modules/gis2/src/gis2/scenario/ClearCiviliansFunction.java
+++ b/modules/gis2/src/gis2/scenario/ClearCiviliansFunction.java
@@ -1,0 +1,58 @@
+package gis2.scenario;
+
+import gis2.GisScenario;
+
+import javax.swing.undo.AbstractUndoableEdit;
+
+/**
+ * Function for removing all civilians.
+ */
+public class ClearCiviliansFunction extends AbstractFunction {
+    /**
+     * Construct a clear civilians function.
+     *
+     * @param editor The editor instance.
+     */
+    public ClearCiviliansFunction(ScenarioEditor editor) {
+        super(editor);
+    }
+
+    @Override
+    public String getName() {
+        return "Remove Civilians";
+    }
+
+    @Override
+    public void execute() {
+        GisScenario scenario = editor.getScenario();
+        ScenarioSnapshot snapshot = new ScenarioSnapshot(scenario);
+        ClearCiviliansEdit clearEdit = new ClearCiviliansEdit(snapshot);
+
+        scenario.clearCivilians();
+        editor.setChanged();
+        editor.updateOverlays();
+        editor.addEdit(clearEdit);
+    }
+
+    private class ClearCiviliansEdit extends AbstractUndoableEdit {
+        private final ScenarioSnapshot snapshot;
+
+        public ClearCiviliansEdit(ScenarioSnapshot snapshot) {
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public void undo() {
+            super.undo();
+            snapshot.restore(editor.getScenario());
+            editor.updateOverlays();
+        }
+
+        @Override
+        public void redo() {
+            super.redo();
+            editor.getScenario().clearCivilians();
+            editor.updateOverlays();
+        }
+    }
+}

--- a/modules/gis2/src/gis2/scenario/ClearFireBrigadesFunction.java
+++ b/modules/gis2/src/gis2/scenario/ClearFireBrigadesFunction.java
@@ -1,0 +1,58 @@
+package gis2.scenario;
+
+import gis2.GisScenario;
+
+import javax.swing.undo.AbstractUndoableEdit;
+
+/**
+ * Function for removing all fire brigades.
+ */
+public class ClearFireBrigadesFunction extends AbstractFunction {
+    /**
+     * Construct a clear fire brigades function.
+     *
+     * @param editor The editor instance.
+     */
+    public ClearFireBrigadesFunction(ScenarioEditor editor) {
+        super(editor);
+    }
+
+    @Override
+    public String getName() {
+        return "Remove Fire Brigades";
+    }
+
+    @Override
+    public void execute() {
+        GisScenario scenario = editor.getScenario();
+        ScenarioSnapshot snapshot = new ScenarioSnapshot(scenario);
+        ClearFireBrigadesEdit clearEdit = new ClearFireBrigadesEdit(snapshot);
+
+        scenario.clearFireBrigades();
+        editor.setChanged();
+        editor.updateOverlays();
+        editor.addEdit(clearEdit);
+    }
+
+    private class ClearFireBrigadesEdit extends AbstractUndoableEdit {
+        private final ScenarioSnapshot snapshot;
+
+        public ClearFireBrigadesEdit(ScenarioSnapshot snapshot) {
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public void undo() {
+            super.undo();
+            snapshot.restore(editor.getScenario());
+            editor.updateOverlays();
+        }
+
+        @Override
+        public void redo() {
+            super.redo();
+            editor.getScenario().clearFireBrigades();
+            editor.updateOverlays();
+        }
+    }
+}

--- a/modules/gis2/src/gis2/scenario/ClearFiresFunction.java
+++ b/modules/gis2/src/gis2/scenario/ClearFiresFunction.java
@@ -2,7 +2,7 @@ package gis2.scenario;
 
 import gis2.GisScenario;
 
-import java.util.HashSet;
+import javax.swing.undo.AbstractUndoableEdit;
 
 /**
  * Function for removing all fires.
@@ -19,14 +19,40 @@ public class ClearFiresFunction extends AbstractFunction {
 
   @Override
   public String getName() {
-    return "Remove fires";
+    return "Remove Fires";
   }
 
   @Override
   public void execute() {
-    GisScenario s = editor.getScenario();
-    s.setFires(new HashSet<Integer>());
+    GisScenario scenario = editor.getScenario();
+    ScenarioSnapshot snapshot = new ScenarioSnapshot(scenario);
+    ClearFiresEdit clearEdit = new ClearFiresEdit(snapshot);
+
+    scenario.clearFires();
     editor.setChanged();
     editor.updateOverlays();
+    editor.addEdit(clearEdit);
+  }
+
+  private class ClearFiresEdit extends AbstractUndoableEdit {
+    private final ScenarioSnapshot snapshot;
+
+    public ClearFiresEdit(ScenarioSnapshot snapshot) {
+      this.snapshot = snapshot;
+    }
+
+    @Override
+    public void undo() {
+      super.undo();
+      snapshot.restore(editor.getScenario());
+      editor.updateOverlays();
+    }
+
+    @Override
+    public void redo() {
+      super.redo();
+      editor.getScenario().clearFires();
+      editor.updateOverlays();
+    }
   }
 }

--- a/modules/gis2/src/gis2/scenario/ClearPoliceForcesFunction.java
+++ b/modules/gis2/src/gis2/scenario/ClearPoliceForcesFunction.java
@@ -1,0 +1,58 @@
+package gis2.scenario;
+
+import gis2.GisScenario;
+
+import javax.swing.undo.AbstractUndoableEdit;
+
+/**
+ * Function for removing all police forces.
+ */
+public class ClearPoliceForcesFunction extends AbstractFunction {
+    /**
+     * Construct a clear police forces function.
+     *
+     * @param editor The editor instance.
+     */
+    public ClearPoliceForcesFunction(ScenarioEditor editor) {
+        super(editor);
+    }
+
+    @Override
+    public String getName() {
+        return "Remove Police Forces";
+    }
+
+    @Override
+    public void execute() {
+        GisScenario scenario = editor.getScenario();
+        ScenarioSnapshot snapshot = new ScenarioSnapshot(scenario);
+        ClearPoliceForcesEdit clearEdit = new ClearPoliceForcesEdit(snapshot);
+
+        scenario.clearPoliceForces();
+        editor.setChanged();
+        editor.updateOverlays();
+        editor.addEdit(clearEdit);
+    }
+
+    private class ClearPoliceForcesEdit extends AbstractUndoableEdit {
+        private final ScenarioSnapshot snapshot;
+
+        public ClearPoliceForcesEdit(ScenarioSnapshot snapshot) {
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public void undo() {
+            super.undo();
+            snapshot.restore(editor.getScenario());
+            editor.updateOverlays();
+        }
+
+        @Override
+        public void redo() {
+            super.redo();
+            editor.getScenario().clearPoliceForces();
+            editor.updateOverlays();
+        }
+    }
+}

--- a/modules/gis2/src/gis2/scenario/PlaceAgentsFunction.java
+++ b/modules/gis2/src/gis2/scenario/PlaceAgentsFunction.java
@@ -12,7 +12,9 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JTextField;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLShape;
 
@@ -20,12 +22,12 @@ import maps.gml.GMLShape;
  * Function for placing agents.
  */
 public class PlaceAgentsFunction extends AbstractFunction {
-  private static final int TYPE_FIRE = 0;
-  private static final int TYPE_POLICE = 1;
+  private static final int TYPE_FIRE      = 0;
+  private static final int TYPE_POLICE    = 1;
   private static final int TYPE_AMBULANCE = 2;
-  private static final int TYPE_CIVILIAN = 3;
+  private static final int TYPE_CIVILIAN  = 3;
 
-  private Random random;
+  private final Random random;
 
   /**
    * Construct a place agents function.
@@ -39,76 +41,87 @@ public class PlaceAgentsFunction extends AbstractFunction {
 
   @Override
   public String getName() {
-    return "Place agents";
+    return "Place Agents";
   }
 
   @Override
   public void execute() {
     JPanel panel = new JPanel(new GridLayout(3, 2));
-    JTextField numberField = new JTextField("1");
-    JComboBox<String> typeCombo = new JComboBox<String>(new String[] { "Fire", "Police", "Ambulance", "Civilian" });
+
+    JComboBox<String> typeCombo = new JComboBox<>(new String[] { "Fire", "Police", "Ambulance", "Civilian" });
+    JSpinner numberSpinner = new JSpinner(new SpinnerNumberModel(1, 0, Integer.MAX_VALUE, 1));
 
     JCheckBox buildingBox = new JCheckBox("In buildings?", false);
     JCheckBox roadBox = new JCheckBox("In Roads?", true);
-    JPanel jp = new JPanel();
-    jp.add(buildingBox);
-    jp.add(roadBox);
+
+    JPanel checkPanel = new JPanel();
+    checkPanel.add(buildingBox);
+    checkPanel.add(roadBox);
 
     panel.add(new JLabel("Type"));
     panel.add(typeCombo);
     panel.add(new JLabel("Number"));
-    panel.add(numberField);
-    panel.add(jp);
-    List<Integer> ids = new ArrayList<Integer>();
-    int type = -1;
-    List<GMLShape> all = new ArrayList<GMLShape>();
-    if (JOptionPane.showConfirmDialog(null, panel, "Add agents",
-        JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION) {
-      try {
-        int number = Integer.parseInt(numberField.getText());
-        type = typeCombo.getSelectedIndex();
-        if (roadBox.isSelected())
-          all.addAll(editor.getMap().getRoads());
-        if (buildingBox.isSelected())
-          all.addAll(editor.getMap().getBuildings());
-        if (all.size() == 0) {
-          JOptionPane.showMessageDialog(null, "No Area to Place... Please choose In Road or Building...", "Error",
-              JOptionPane.ERROR_MESSAGE);
-          return;
-        }
-        for (int i = 0; i < number; ++i) {
-          ids.add(all.get(random.nextInt(all.size())).getID());
-        }
-      } catch (NumberFormatException e) {
-        e.printStackTrace();
-      }
+    panel.add(numberSpinner);
+    panel.add(checkPanel);
+
+    if (JOptionPane.showConfirmDialog(null, panel, getName(), JOptionPane.OK_CANCEL_OPTION) != JOptionPane.OK_OPTION) return;
+
+    List<GMLShape> candidateAreas = new ArrayList<>();
+    if (roadBox.isSelected()) candidateAreas.addAll(editor.getMap().getRoads());
+    if (buildingBox.isSelected()) candidateAreas.addAll(editor.getMap().getBuildings());
+    if (candidateAreas.isEmpty()) {
+      String message = "No Area to Place... Please choose In Road or Building...";
+      JOptionPane.showMessageDialog(null, message, "Error", JOptionPane.ERROR_MESSAGE);
+      return;
     }
-    GisScenario s = editor.getScenario();
-    switch (type) {
-      case TYPE_FIRE:
-        for (int id : ids) {
-          s.addFireBrigade(id);
-        }
-        break;
-      case TYPE_POLICE:
-        for (int id : ids) {
-          s.addPoliceForce(id);
-        }
-        break;
-      case TYPE_AMBULANCE:
-        for (int id : ids) {
-          s.addAmbulanceTeam(id);
-        }
-        break;
-      case TYPE_CIVILIAN:
-        for (int id : ids) {
-          s.addCivilian(id);
-        }
-        break;
-      default:
-        throw new IllegalArgumentException("Unexpected type: " + type);
+
+    List<Integer> locations = new ArrayList<>();
+    int number = (int) numberSpinner.getValue();
+    for (int i = 0; i < number; ++i) {
+      locations.add(candidateAreas.get(random.nextInt(candidateAreas.size())).getID());
     }
+
+    GisScenario scenario = editor.getScenario();
+    ScenarioSnapshot beforeSnapshot = new ScenarioSnapshot(scenario);
+
+    int agentType = typeCombo.getSelectedIndex();
+    switch (agentType) {
+      case TYPE_FIRE      -> locations.forEach(scenario::addFireBrigade);
+      case TYPE_AMBULANCE -> locations.forEach(scenario::addAmbulanceTeam);
+      case TYPE_POLICE    -> locations.forEach(scenario::addPoliceForce);
+      case TYPE_CIVILIAN  -> locations.forEach(scenario::addCivilian);
+      default -> throw new IllegalArgumentException("Unexpected type: " + agentType);
+    }
+
+    ScenarioSnapshot afterSnapshot = new ScenarioSnapshot(scenario);
+    PlaceAgentsEdit placeEdit = new PlaceAgentsEdit(beforeSnapshot, afterSnapshot);
+
     editor.setChanged();
     editor.updateOverlays();
+    editor.addEdit(placeEdit);
+  }
+
+  private class PlaceAgentsEdit extends AbstractUndoableEdit {
+    private final ScenarioSnapshot beforeSnapshot;
+    private final ScenarioSnapshot afterSnapshot;
+
+    public PlaceAgentsEdit(ScenarioSnapshot beforeSnapshot, ScenarioSnapshot afterSnapshot) {
+      this.beforeSnapshot = beforeSnapshot;
+      this.afterSnapshot = afterSnapshot;
+    }
+
+    @Override
+    public void undo() {
+      super.undo();
+      beforeSnapshot.restore(editor.getScenario());
+      editor.updateOverlays();
+    }
+
+    @Override
+    public void redo() {
+      super.redo();
+      afterSnapshot.restore(editor.getScenario());
+      editor.updateOverlays();
+    }
   }
 }

--- a/modules/gis2/src/gis2/scenario/RandomHydrantPlacementFunction.java
+++ b/modules/gis2/src/gis2/scenario/RandomHydrantPlacementFunction.java
@@ -4,14 +4,16 @@ import gis2.GisScenario;
 
 import java.awt.GridLayout;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JTextField;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.undo.AbstractUndoableEdit;
 
 import maps.gml.GMLMap;
 import maps.gml.GMLShape;
@@ -20,7 +22,7 @@ import maps.gml.GMLShape;
  * Function for placing agents.
  */
 public class RandomHydrantPlacementFunction extends AbstractFunction {
-  private Random random;
+  private final Random random;
 
   /**
    * Construct a place agents function.
@@ -40,34 +42,59 @@ public class RandomHydrantPlacementFunction extends AbstractFunction {
   @Override
   public void execute() {
     JPanel panel = new JPanel(new GridLayout(3, 2));
-    JTextField numberField = new JTextField("1");
+    JSpinner numberSpinner = new JSpinner(new SpinnerNumberModel(1, 0, Integer.MAX_VALUE, 1));
+    panel.add(new JLabel("Number: suggested number:" + calcSuggestedNumber()));
+    panel.add(numberSpinner);
+
+    if (JOptionPane.showConfirmDialog(null, panel, getName(), JOptionPane.OK_CANCEL_OPTION) != JOptionPane.OK_OPTION) return;
+
+    List<GMLShape> candidateRoads = new ArrayList<>(editor.getMap().getRoads());
+    GisScenario scenario = editor.getScenario();
+    ScenarioSnapshot beforeSnapshot = new ScenarioSnapshot(scenario);
+    int number = (int) numberSpinner.getValue();
+
+    Collections.shuffle(candidateRoads, random);
+    for (int i = 0; i < number; ++i) {
+      int location = candidateRoads.get(i).getID();
+      scenario.addHydrant(location);
+    }
+
+    ScenarioSnapshot afterSnapshot = new ScenarioSnapshot(scenario);
+    RandomHydrantPlacementEdit randomEdit = new RandomHydrantPlacementEdit(beforeSnapshot, afterSnapshot);
+
+    editor.setChanged();
+    editor.updateOverlays();
+    editor.addEdit(randomEdit);
+  }
+
+  private int calcSuggestedNumber() {
     GMLMap map = editor.getMap();
     double height = (map.getMaxX() - map.getMinX());
     double width = (map.getMaxY() - map.getMinY());
-    int suggestedCount = (int) (height * width / 30000);
-    panel.add(new JLabel("Number: suggested number:" + suggestedCount));
-    panel.add(numberField);
-    HashSet<Integer> selectedIds = new HashSet<>();
-    List<GMLShape> all = new ArrayList<GMLShape>(editor.getMap().getRoads());
-    if (JOptionPane.showConfirmDialog(null, panel, "Add agents",
-        JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION) {
-      GisScenario s = editor.getScenario();
-      try {
-        int number = Integer.parseInt(numberField.getText());
-        for (int i = 0; i < number; ++i) {
-          int id = all.get(random.nextInt(all.size())).getID();
-          if (selectedIds.contains(id))
-            i--;
-          else {
-            s.addHydrant(id);
-            selectedIds.add(id);
-          }
-        }
-      } catch (NumberFormatException e) {
-        e.printStackTrace();
-      }
+    return (int) Math.ceil(height * width / 30000);
+  }
+
+  private class RandomHydrantPlacementEdit extends AbstractUndoableEdit {
+    private final ScenarioSnapshot beforeSnapshot;
+    private final ScenarioSnapshot afterSnapshot;
+
+    public RandomHydrantPlacementEdit(ScenarioSnapshot beforeSnapshot, ScenarioSnapshot afterSnapshot) {
+      this.beforeSnapshot = beforeSnapshot;
+      this.afterSnapshot = afterSnapshot;
     }
-    editor.setChanged();
-    editor.updateOverlays();
+
+    @Override
+    public void undo() {
+      super.undo();
+      beforeSnapshot.restore(editor.getScenario());
+      editor.updateOverlays();
+    }
+
+    @Override
+    public void redo() {
+      super.redo();
+      afterSnapshot.restore(editor.getScenario());
+      editor.updateOverlays();
+    }
   }
 }

--- a/modules/gis2/src/gis2/scenario/ScenarioEditor.java
+++ b/modules/gis2/src/gis2/scenario/ScenarioEditor.java
@@ -587,11 +587,11 @@ public class ScenarioEditor extends JPanel {
   }
 
   private void createFunctionActions(JMenu menu, JToolBar toolbar) {
-    addFunction(new RandomiseFunction(this), menu, toolbar);
-    addFunction(new ClearFiresFunction(this), menu, toolbar);
     addFunction(new ClearAgentsFunction(this), menu, toolbar);
     addFunction(new ClearAllFunction(this), menu, toolbar);
     addFunction(new PlaceAgentsFunction(this), menu, toolbar);
+    addFunction(new RandomiseFunction(this), menu, toolbar);
+    addFunction(new ClearFiresFunction(this), menu, toolbar);
     addFunction(new RandomHydrantPlacementFunction(this), menu, toolbar);
   }
 

--- a/modules/gis2/src/gis2/scenario/ScenarioEditor.java
+++ b/modules/gis2/src/gis2/scenario/ScenarioEditor.java
@@ -587,6 +587,10 @@ public class ScenarioEditor extends JPanel {
   }
 
   private void createFunctionActions(JMenu menu, JToolBar toolbar) {
+    addFunction(new ClearCiviliansFunction(this), menu, toolbar);
+    addFunction(new ClearFireBrigadesFunction(this), menu, toolbar);
+    addFunction(new ClearAmbulanceTeamsFunction(this), menu, toolbar);
+    addFunction(new ClearPoliceForcesFunction(this), menu, toolbar);
     addFunction(new ClearAgentsFunction(this), menu, toolbar);
     addFunction(new ClearAllFunction(this), menu, toolbar);
     addFunction(new PlaceAgentsFunction(this), menu, toolbar);

--- a/modules/gis2/src/gis2/scenario/ScenarioEditor.java
+++ b/modules/gis2/src/gis2/scenario/ScenarioEditor.java
@@ -7,6 +7,8 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
@@ -151,12 +153,12 @@ public class ScenarioEditor extends JPanel {
     createEditActions(editMenu, editToolbar);
     createFunctionActions(functionsMenu, functionsToolbar);
 
-    JToolBar toolbar = new JToolBar();
-    toolbar.setFloatable(false);
-    toolbar.setLayout(new FlowLayout(FlowLayout.LEFT));
-    toolbar.add(fileToolbar);
-    toolbar.add(editToolbar);
-    toolbar.add(functionsToolbar);
+    JToolBar toolBar = new JToolBar();
+    toolBar.setFloatable(false);
+    toolBar.setLayout(new FlowLayout(FlowLayout.LEFT));
+    toolBar.add(fileToolbar);
+    toolBar.add(editToolbar);
+    toolBar.add(functionsToolbar);
 
     JToolBar toolPanel = new JToolBar("Tools");
     toolPanel.addPropertyChangeListener("ancestor", event -> {
@@ -167,12 +169,8 @@ public class ScenarioEditor extends JPanel {
     });
     createToolActions(toolsMenu, toolPanel);
 
-    JScrollPane toolBarScroll = new JScrollPane(toolbar,
-            JScrollPane.VERTICAL_SCROLLBAR_NEVER,
-            JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-    JScrollPane toolPanelScroll = new JScrollPane(toolPanel,
-            JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
-            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+    JScrollPane toolBarScroll   = createToolBarScroll(toolBar);
+    JScrollPane toolPanelScroll = createToolPanelScroll(toolPanel);
 
     add(viewer, BorderLayout.CENTER);
     add(toolBarScroll, BorderLayout.NORTH);
@@ -187,6 +185,49 @@ public class ScenarioEditor extends JPanel {
     saveFile = null;
   }
 
+  private JScrollPane createToolBarScroll(JToolBar toolBar) {
+    JScrollPane toolBarScroll = new JScrollPane(toolBar,
+            JScrollPane.VERTICAL_SCROLLBAR_NEVER,
+            JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+
+    toolBarScroll.getHorizontalScrollBar().addComponentListener(new ComponentAdapter() {
+      @Override
+      public void componentShown(ComponentEvent e) {
+        toolBarScroll.setPreferredSize(new Dimension(PREFERRED_WIDTH, 60));
+        toolBarScroll.revalidate();
+      }
+
+      @Override
+      public void componentHidden(ComponentEvent e) {
+        toolBarScroll.setPreferredSize(new Dimension(PREFERRED_WIDTH, 45));
+        toolBarScroll.revalidate();
+      }
+    });
+
+    return toolBarScroll;
+  }
+
+  private JScrollPane createToolPanelScroll(JToolBar toolPanel) {
+    JScrollPane toolPanelScroll = new JScrollPane(toolPanel,
+            JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+
+    toolPanelScroll.getVerticalScrollBar().addComponentListener(new ComponentAdapter() {
+      @Override
+      public void componentShown(ComponentEvent e) {
+        toolPanelScroll.setPreferredSize(new Dimension(60, PREFERRED_HEIGHT));
+        toolPanelScroll.revalidate();
+      }
+
+      @Override
+      public void componentHidden(ComponentEvent e) {
+        toolPanelScroll.setPreferredSize(new Dimension(45, PREFERRED_HEIGHT));
+        toolPanelScroll.revalidate();
+      }
+    });
+
+    return toolPanelScroll;
+  }
 
   /**
    * Entry point.
@@ -229,7 +270,6 @@ public class ScenarioEditor extends JPanel {
     frame.setVisible(true);
   }
 
-
   /**
    * Load a map and scenario by showing a file chooser dialog.
    *
@@ -269,7 +309,6 @@ public class ScenarioEditor extends JPanel {
     }
   }
 
-
   /**
    * Load a map and scenario from a directory.
    *
@@ -295,7 +334,6 @@ public class ScenarioEditor extends JPanel {
       rescuecore2.scenario.exceptions.ScenarioException {
     load(new File(filename));
   }
-
 
   /**
    * Load a map and scenario from a directory.
@@ -334,7 +372,6 @@ public class ScenarioEditor extends JPanel {
     }
   }
 
-
   /**
    * Set the map and scenario.
    *
@@ -361,7 +398,6 @@ public class ScenarioEditor extends JPanel {
     viewer.setMap(map);
     updateOverlays();
   }
-
 
   public void updateGMLRefuges() {
     for (int next : scenario.getRefuges()) {
@@ -665,7 +701,6 @@ public class ScenarioEditor extends JPanel {
     action.putValue(Action.SHORT_DESCRIPTION, t.getName());
     check.setAction(action);
     toggle.setAction(action);
-//    toggle.setMaximumSize(new Dimension(300, 30));
     toggle.setText("");
     menu.add(check);
     toolbar.add(toggle);

--- a/modules/gis2/src/gis2/scenario/ScenarioEditor.java
+++ b/modules/gis2/src/gis2/scenario/ScenarioEditor.java
@@ -4,6 +4,7 @@ import gis2.GisScenario;
 import gis2.ScenarioException;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
@@ -29,6 +30,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
+import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import javax.swing.filechooser.FileFilter;
@@ -160,13 +162,7 @@ public class ScenarioEditor extends JPanel {
     toolBar.add(editToolbar);
     toolBar.add(functionsToolbar);
 
-    JToolBar toolPanel = new JToolBar("Tools");
-    toolPanel.addPropertyChangeListener("ancestor", event -> {
-      toolPanel.setOrientation(JToolBar.VERTICAL);
-      if (toolPanel.getParent() instanceof JPanel) {
-        this.revalidate();
-      }
-    });
+    JToolBar toolPanel = createToolPanel();
     createToolActions(toolsMenu, toolPanel);
 
     JScrollPane toolBarScroll   = createToolBarScroll(toolBar);
@@ -183,6 +179,33 @@ public class ScenarioEditor extends JPanel {
 
     baseDir = new File(System.getProperty("user.dir"));
     saveFile = null;
+  }
+
+  private JToolBar createToolPanel() {
+    JToolBar toolPanel = new JToolBar("Tools");
+
+    toolPanel.addPropertyChangeListener("ancestor", event -> {
+      toolPanel.setOrientation(JToolBar.VERTICAL);
+      boolean isFloating = toolPanel.getParent() instanceof JPanel;
+
+      if (isFloating) {
+        for (Component component : toolPanel.getComponents()) {
+          if (!(component instanceof JToggleButton toggle)) continue;
+          Action action = toggle.getAction();
+          if (action == null) continue;
+          toggle.setText((String) action.getValue(Action.NAME));
+          toggle.setMaximumSize(new Dimension(500, 30));
+        }
+      } else {
+        for (Component component : toolPanel.getComponents()) {
+          if (!(component instanceof JToggleButton toggle)) continue;
+          toggle.setText("");
+        }
+      }
+      this.revalidate();
+    });
+
+    return toolPanel;
   }
 
   private JScrollPane createToolBarScroll(JToolBar toolBar) {
@@ -699,9 +722,15 @@ public class ScenarioEditor extends JPanel {
     };
     action.putValue(Action.SMALL_ICON, t.getIcon());
     action.putValue(Action.SHORT_DESCRIPTION, t.getName());
-    check.setAction(action);
+
     toggle.setAction(action);
     toggle.setText("");
+    toggle.setHorizontalAlignment(SwingConstants.LEFT);
+
+    check.setAction(action);
+    check.setIcon(null);
+    check.setToolTipText(null);
+
     menu.add(check);
     toolbar.add(toggle);
     menuGroup.add(check);

--- a/modules/gis2/src/gis2/scenario/ScenarioSnapshot.java
+++ b/modules/gis2/src/gis2/scenario/ScenarioSnapshot.java
@@ -1,0 +1,63 @@
+package gis2.scenario;
+
+import gis2.GisScenario;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A snapshot of a {@link GisScenario}.
+ */
+public class ScenarioSnapshot {
+    private final Collection<Integer> civilians;
+    private final Collection<Integer> fireBrigades;
+    private final Collection<Integer> ambulanceTeams;
+    private final Collection<Integer> policeForces;
+    private final Collection<Integer> fireStations;
+    private final Collection<Integer> ambulanceCentres;
+    private final Collection<Integer> policeOffices;
+    private final HashMap<Integer, Integer> refuges;
+    private final Set<Integer> hydrants;
+    private final Set<Integer> gasStations;
+    private final Set<Integer> fires;
+
+    /**
+     * Create a snapshot of the given {@link GisScenario}.
+     *
+     * @param scenario The scenario to snapshot.
+     */
+    public ScenarioSnapshot(GisScenario scenario) {
+        civilians        = new HashSet<>(scenario.getCivilians());
+        fireBrigades     = new HashSet<>(scenario.getFireBrigades());
+        ambulanceTeams   = new HashSet<>(scenario.getAmbulanceTeams());
+        policeForces     = new HashSet<>(scenario.getPoliceForces());
+        fireStations     = new HashSet<>(scenario.getFireStations());
+        ambulanceCentres = new HashSet<>(scenario.getAmbulanceCentres());
+        policeOffices    = new HashSet<>(scenario.getPoliceOffices());
+        refuges          = new HashMap<>(scenario.getRefugeBedCapacity());
+        hydrants         = new HashSet<>(scenario.getHydrants());
+        gasStations      = new HashSet<>(scenario.getGasStations());
+        fires            = new HashSet<>(scenario.getFires());
+    }
+
+    /**
+     * Restore this snapshot into the given {@link GisScenario}.
+     *
+     * @param scenario The scenario to restore into.
+     */
+    public void restore(GisScenario scenario) {
+        scenario.setCivilians(civilians);
+        scenario.setFireBrigades(fireBrigades);
+        scenario.setAmbulanceTeams(ambulanceTeams);
+        scenario.setPoliceForces(policeForces);
+        scenario.setFireStations(fireStations);
+        scenario.setAmbulanceCentres(ambulanceCentres);
+        scenario.setPoliceOffices(policeOffices);
+        scenario.setRefuges(refuges);
+        scenario.setHydrants(hydrants);
+        scenario.setGasStations(gasStations);
+        scenario.setFires(fires);
+    }
+}


### PR DESCRIPTION
When creating a scenario in the ScenarioEditor, we sometimes needed to reposition agents.
However, the only available options were to delete all agents or delete them one-by-one, which was inconvenient.

This PR addresses this issue by adding a new function to clear all agents of a specific type.

Additionally, the following improvements have been made:

- Implemented Undo/Redo support for **all functions**.
- Improved the appearance of the floating toolbar.
- Fixed toolbar and tool panel resizing to correctly account for scrollbar dimensions.