### PR TITLE
Fix bug causing inconsistent neighboring shapes in SplitShapeTool of gmlEditor

### DIFF
--- a/modules/maps/src/maps/gml/GMLMap.java
+++ b/modules/maps/src/maps/gml/GMLMap.java
@@ -961,6 +961,23 @@ public class GMLMap implements maps.Map {
         return result;
     }
 
+    public void toggleEdgePassable(GMLEdge target, boolean isPassable) {
+        target.setPassable(isPassable);
+
+        Collection<GMLShape> attached = getAttachedShapes(target);
+        Iterator<GMLShape> it = attached.iterator();
+        GMLShape first = it.next();
+        GMLShape second = it.next();
+        if (isPassable) {
+            first.setNeighbour(target, second.getID());
+            second.setNeighbour(target, first.getID());
+        }
+        else {
+            first.setNeighbour(target, null);
+            second.setNeighbour(target, null);
+        }
+    }
+
     private void addShape(GMLShape shape) {
         addObject(shape);
         allShapes.add(shape);

--- a/modules/maps/src/maps/gml/editor/SplitShapeTool.java
+++ b/modules/maps/src/maps/gml/editor/SplitShapeTool.java
@@ -198,7 +198,7 @@ public class SplitShapeTool extends AbstractTool {
         }
       }
       if ( !add.isEmpty() ) {
-        edge.setPassable( true );
+        editor.getMap().toggleEdgePassable(edge, true);
         return new SplitShapeEdit( edge, add, delete );
       } else {
         editor.getMap().remove( edge );

--- a/modules/maps/src/maps/gml/editor/SplitShapeTool.java
+++ b/modules/maps/src/maps/gml/editor/SplitShapeTool.java
@@ -13,13 +13,7 @@ import java.util.List;
 
 import javax.swing.undo.AbstractUndoableEdit;
 
-import maps.gml.GMLBuilding;
-import maps.gml.GMLCoordinates;
-import maps.gml.GMLEdge;
-import maps.gml.GMLNode;
-import maps.gml.GMLRoad;
-import maps.gml.GMLShape;
-import maps.gml.GMLSpace;
+import maps.gml.*;
 import maps.gml.view.LineOverlay;
 import maps.gml.view.NodeDecorator;
 import maps.gml.view.SquareNodeDecorator;
@@ -134,6 +128,16 @@ public class SplitShapeTool extends AbstractTool {
     editor.getViewer().repaint();
   }
 
+  protected void fixNeighbourShapes(Collection<GMLShape> added) {
+    for (GMLShape addedShape : added) {
+      for (GMLDirectedEdge directedEdge : addedShape.getEdges()) {
+        GMLEdge checkingTargetEdge = directedEdge.getEdge();
+        if (checkingTargetEdge.isPassable()) {
+          editor.getMap().toggleEdgePassable(checkingTargetEdge, true);
+        }
+      }
+    }
+  }
 
   private class Listener implements MouseListener, MouseMotionListener {
 
@@ -199,6 +203,7 @@ public class SplitShapeTool extends AbstractTool {
       }
       if ( !add.isEmpty() ) {
         editor.getMap().toggleEdgePassable(edge, true);
+        fixNeighbourShapes(add);
         return new SplitShapeEdit( edge, add, delete );
       } else {
         editor.getMap().remove( edge );
@@ -340,6 +345,7 @@ public class SplitShapeTool extends AbstractTool {
       editor.getMap().removeEdge( edge );
       editor.getMap().remove( add );
       editor.getMap().add( remove );
+      fixNeighbourShapes(remove);
       editor.getViewer().repaint();
     }
 
@@ -356,6 +362,7 @@ public class SplitShapeTool extends AbstractTool {
       }
       editor.getMap().remove( remove );
       editor.getMap().add( add );
+      fixNeighbourShapes(add);
       editor.getViewer().repaint();
     }
   }

--- a/modules/maps/src/maps/gml/editor/TogglePassableTool.java
+++ b/modules/maps/src/maps/gml/editor/TogglePassableTool.java
@@ -79,19 +79,7 @@ public class TogglePassableTool extends AbstractTool {
     }
 
     private void setPassable(GMLEdge edge, boolean passable) {
-        edge.setPassable(passable);
-        Collection<GMLShape> attached = editor.getMap().getAttachedShapes(edge);
-        Iterator<GMLShape> it = attached.iterator();
-        GMLShape first = it.next();
-        GMLShape second = it.next();
-        if (passable) {
-            first.setNeighbour(edge, second.getID());
-            second.setNeighbour(edge, first.getID());
-        }
-        else {
-            first.setNeighbour(edge, null);
-            second.setNeighbour(edge, null);
-        }
+        editor.getMap().toggleEdgePassable(edge, passable);
         editor.setChanged();
         editor.getViewer().repaint();
     }


### PR DESCRIPTION
Previously, when a shape was split, the neighboring shape IDs could become inconsistent. As a result, the UI might display the shape as Passable, while the saved data did not correctly reflect that state. In some cases, the saved data even recorded non-existent shapes as neighbors.

This fix includes:
- Adding a process to correctly update neighboring shape IDs after a split.
- Updating the Redo/Undo logic to ensure consistency with these changes.