### PR TITLE
Fix JitPack SNAPSHOT resolution

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,4 @@
-before_install:
-  - source "$HOME/.sdkman/bin/sdkman-init.sh"
-  - sdk update
-  - sdk install java 17.0.1-tem
-  - sdk use java 17.0.1-tem
+jdk:
+  - openjdk17
+install:
+  - ./gradlew publishToMavenLocal -Dmaven.repo.local=$HOME/.m2/repository


### PR DESCRIPTION
Added `jitpack.yml` to ensure stable dependency resolution for `master-SNAPSHOT` via JitPack.

Currently, using this repository as a `master-SNAPSHOT` via JitPack often leads to build failures because `.pom` files are not found :(

**ERROR MESSAGE**:
```
* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find com.github.roborescue:rcrs-server:master-SNAPSHOT.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/github/roborescue/rcrs-server/master-SNAPSHOT/maven-metadata.xml
       - https://repo.maven.apache.org/maven2/com/github/roborescue/rcrs-server/master-SNAPSHOT/rcrs-server-master-SNAPSHOT.pom
       - https://sourceforge.net/projects/jsi/files/m2_repo/com/github/roborescue/rcrs-server/master-SNAPSHOT/maven-metadata.xml
       - https://sourceforge.net/projects/jsi/files/m2_repo/com/github/roborescue/rcrs-server/master-SNAPSHOT/rcrs-server-master-SNAPSHOT.pom
       - https://repo.enonic.com/public/com/github/roborescue/rcrs-server/master-SNAPSHOT/maven-metadata.xml
       - https://repo.enonic.com/public/com/github/roborescue/rcrs-server/master-SNAPSHOT/rcrs-server-master-SNAPSHOT.pom
       - https://jitpack.io/com/github/roborescue/rcrs-server/master-SNAPSHOT/maven-metadata.xml
       - https://jitpack.io/com/github/roborescue/rcrs-server/master-SNAPSHOT/rcrs-server-master-eacdfec247-1.pom
     Required by:
         project :
   > Could not find com.github.roborescue:adf-core-java:master-SNAPSHOT.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/github/roborescue/adf-core-java/master-SNAPSHOT/maven-metadata.xml
       - https://repo.maven.apache.org/maven2/com/github/roborescue/adf-core-java/master-SNAPSHOT/adf-core-java-master-SNAPSHOT.pom
       - https://sourceforge.net/projects/jsi/files/m2_repo/com/github/roborescue/adf-core-java/master-SNAPSHOT/maven-metadata.xml
       - https://sourceforge.net/projects/jsi/files/m2_repo/com/github/roborescue/adf-core-java/master-SNAPSHOT/adf-core-java-master-SNAPSHOT.pom
       - https://repo.enonic.com/public/com/github/roborescue/adf-core-java/master-SNAPSHOT/maven-metadata.xml
       - https://repo.enonic.com/public/com/github/roborescue/adf-core-java/master-SNAPSHOT/adf-core-java-master-SNAPSHOT.pom
       - https://jitpack.io/com/github/roborescue/adf-core-java/master-SNAPSHOT/maven-metadata.xml
       - https://jitpack.io/com/github/roborescue/adf-core-java/master-SNAPSHOT/adf-core-java-master-a05c71571b-1.pom
     Required by:
         project :
```

---

If you directly specify the commit ID containing the JitPack artifact as shown in the image below, the build will succeed.

<img width="668" height="490" alt="image" src="https://github.com/user-attachments/assets/da1cd800-1f0a-42c3-bcea-ee5127df81e3" />

While the build error occurs because the data cannot be found, the URL is valid and the madata exists.
URL: https://jitpack.io/com/github/roborescue/rcrs-server/master-SNAPSHOT/maven-metadata.xml

<img width="863" height="227" alt="image" src="https://github.com/user-attachments/assets/539282aa-deb0-493f-a1a9-8d7b7dae3194" />

---

So, when I made fork project and specified it, and it build successfully.
To stablilize the artifact resolution flow, I've explicitly configured `publishToMavenLocal` to `jitpack.yml`.
This also builds without issues.
But, I'm not sure if it's truly stable yet.

`adf-core-java` repo is experiencing the same issue.
I hope the same fix will work for it.

I would appriciate your feedback on this.

