### PR TITLE
Fix an issue where `start.sh` fails on the first run after cloning the repository

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -156,7 +156,7 @@ function processArgs {
   fi
 
   if [ "$(uname -s)" = 'Linux' ]; then
-    LOGDIR=`readlink -f $LOGDIR`
+    LOGDIR=`readlink -m $LOGDIR`
   fi
   mkdir -p $LOGDIR
   mkdir -p $RECORDSDIR


### PR DESCRIPTION
Fix an issue where `start.sh` fails on the first time, the `logs/log` directory does not exist.
In `function.sh`, `readlink -f` is used to resolve the absolute path of `$LOGDIR`, but `-f` requires all components of the path to exist.
As a result, `readlink -f` returns an empty string, and the subsequent `mkdir -p $LOGDIR` fails.
This causes the kernel to fail to start.

This PR replaces `readlink -f` with `readlink -m`, which resolves the absolute path even if the directory does not exists.